### PR TITLE
fix: anydns bump + pkdns v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "any-dns"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1edacbeccbc03fc35a62525fbe01ad2aee22b1008a1b93b2fa121feaa27980"
+checksum = "3b82d1252692c20073ce26a0bd1189659050d756ea08506948207d043e94a7e4"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "pkdns"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "any-dns",
  "anyhow",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "pkdns-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkdns-cli"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["SeverinAlexB <severin@synonym.to>"]
 edition = "2021"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkdns"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -13,7 +13,7 @@ pkarr = { version = "1.0.4", features = ["dht", "async"]}
 zbase32 = "0.1.2"
 ttl_cache = "0.5.1"
 clap = "4.4.18"
-any-dns = "0.2.4"
+any-dns = "0.2.5"
 chrono = "0.4.33"
 tokio = { version = "1.36.0", features = ["full"] }
 async-trait = "0.1.77"


### PR DESCRIPTION
Version bumps anydns which comes with a bug fix to resolve #11 `slice index starts at 1025 but ends at 1024`.

This bug made pkdns panic in case the UDP datagram was exactly 1024 bytes.