### PR TITLE
feat: Improved logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +800,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -869,6 +891,8 @@ dependencies = [
  "pkarr",
  "simple-dns",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "ttl_cache",
  "zbase32",
 ]
@@ -1064,6 +1088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1306,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1291,6 +1360,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1379,6 +1454,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,15 +92,15 @@ dependencies = [
 
 [[package]]
 name = "any-dns"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82d1252692c20073ce26a0bd1189659050d756ea08506948207d043e94a7e4"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "dyn-clone",
  "simple-dns",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -698,6 +707,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1015,50 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -1326,10 +1388,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here are some example pkarr domains:
 - [http://pkdns.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy./](http://pkdns.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy./)
 
 
-Hint: Always add a `/` to the end of a pkarr domain. Otherwise browsers will search instead of resolve the website.
+Hint: Always add a `./` to the end of a pkarr domain. Otherwise browsers will search instead of resolve the website.
 
 ### Address already in use
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,3 +17,5 @@ chrono = "0.4.33"
 tokio = { version = "1.36.0", features = ["full"] }
 async-trait = "0.1.77"
 anyhow = "1.0.79"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,10 +12,11 @@ pkarr = { version = "2.2.0", features = ["dht", "async", "rand"]}
 zbase32 = "0.1.2"
 ttl_cache = "0.5.1"
 clap = "4.4.18"
-any-dns = "0.3.1"
+# any-dns = "0.3.1"
+any-dns = {path = "/Users/severinbuhler/git/pknames/any-dns"}
 chrono = "0.4.33"
 tokio = { version = "1.36.0", features = ["full"] }
 async-trait = "0.1.77"
 anyhow = "1.0.79"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = {version = "0.3.18", features = ["smallvec", "fmt", "ansi", "tracing-log", "std", "env-filter"]}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,7 +12,7 @@ pkarr = { version = "2.2.0", features = ["dht", "async", "rand"]}
 zbase32 = "0.1.2"
 ttl_cache = "0.5.1"
 clap = "4.4.18"
-any-dns = "0.2.5"
+any-dns = "0.3.1"
 chrono = "0.4.33"
 tokio = { version = "1.36.0", features = ["full"] }
 async-trait = "0.1.77"

--- a/server/pkdns.service
+++ b/server/pkdns.service
@@ -4,7 +4,7 @@ Description=pkdns - Self-Sovereign And Censorship-Resistant Domain Names
 After=network-online.target
 
 [Service]
-# Update the binary path and optionally the forward DNS server.
+# Update the binary path. 
 ExecStart=/usr/local/bin/pkdns --forward 8.8.8.8:53 --verbose
 Environment="RUST_BACKTRACE=full"
 Restart=on-failure

--- a/server/src/helpers.rs
+++ b/server/src/helpers.rs
@@ -1,0 +1,14 @@
+use std::env;
+
+/**
+ * Sets `RUST_BACKTRACE=full` as default so we always get a full stacktrace
+ * on an error.
+ */
+pub (crate) fn set_full_stacktrace_as_default() -> () {
+    let key = "RUST_BACKTRACE";
+    let value = env::var(key);
+    if value.is_ok() {
+        return;
+    }
+    env::set_var(key, "full");
+}

--- a/server/src/helpers.rs
+++ b/server/src/helpers.rs
@@ -1,4 +1,6 @@
 use std::env;
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing::{Level};
 
 /**
  * Sets `RUST_BACKTRACE=full` as default so we always get a full stacktrace
@@ -10,5 +12,44 @@ pub (crate) fn set_full_stacktrace_as_default() -> () {
     if value.is_ok() {
         return;
     }
-    env::set_var(key, "full");
+    env::set_var(key, "1");
+}
+
+
+pub (crate) fn enable_logging(verbose: bool) {
+    let key = "RUST_LOG";
+    let is_env_var_set = env::var(key).is_ok();
+
+    if is_env_var_set {
+        tracing_subscriber::fmt().init();
+        if verbose {
+            tracing::warn!("Custom RUST_LOG= env variable is set. Ignore --verbose flag.")
+        }
+        return
+    }
+
+    let regular_filter = tracing_subscriber::filter::Targets::new()
+    .with_target("pkdns", Level::INFO)
+    .with_target("any_dns", Level::INFO)
+    .with_target("mainline", Level::WARN);
+
+    let verbose_filter = tracing_subscriber::filter::Targets::new()
+    .with_target("pkdns", Level::DEBUG)
+    .with_target("any_dns", Level::DEBUG)
+    .with_target("mainline", Level::WARN);
+
+    let mut filter: Targets = regular_filter;
+    if verbose {
+        filter = verbose_filter;
+    }
+
+
+    tracing_subscriber::registry()
+    .with(tracing_subscriber::fmt::layer())
+    .with(filter)
+    .init();
+
+    if verbose {
+        tracing::info!("Verbose mode enabled.");
+    }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,7 @@
 use any_dns::{Builder, CustomHandler, CustomHandlerError, DnsSocket};
 use async_trait::async_trait;
 
-use helpers::set_full_stacktrace_as_default;
+use helpers::{enable_logging, set_full_stacktrace_as_default};
 use pkarr_resolver::PkarrResolver;
 use std::{error::Error, net::SocketAddr};
 
@@ -38,8 +38,6 @@ impl CustomHandler for MyHandler {
 async fn main() -> Result<(), Box<dyn Error>> {
     set_full_stacktrace_as_default();
     const VERSION: &str = env!("CARGO_PKG_VERSION");
-    tracing_subscriber::fmt::init();
-    tracing::debug!("Starting pkdns v{VERSION}");
 
     let cmd = clap::Command::new("pkdns")
         .about("A DNS server for pkarr self-sovereign domains.")
@@ -100,9 +98,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let socket: &String = matches.get_one("socket").unwrap();
     let socket: SocketAddr = socket.parse().expect("socket should be valid IP:Port combination.");
 
-    if verbose {
-        tracing::info!("--verbose flag is deprecated. Set the environment variable `RUST_LOG=pkdns=debug` instead.");
-    }
+
+    enable_logging(verbose);
+    
+    tracing::info!("Starting pkdns v{VERSION}");
+
     if cache_ttl != 60 {
         tracing::info!("Set cache-ttl to {cache_ttl}s");
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,14 @@
 use any_dns::{Builder, CustomHandler, CustomHandlerError, DnsSocket};
 use async_trait::async_trait;
 
+use helpers::set_full_stacktrace_as_default;
 use pkarr_resolver::PkarrResolver;
 use std::{error::Error, net::SocketAddr};
 
 mod packet_lookup;
 mod pkarr_cache;
 mod pkarr_resolver;
+mod helpers;
 
 #[derive(Clone)]
 struct MyHandler {
@@ -34,6 +36,7 @@ impl CustomHandler for MyHandler {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    set_full_stacktrace_as_default();
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     tracing_subscriber::fmt::init();
     tracing::debug!("Starting pkdns v{VERSION}");
@@ -98,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let socket: SocketAddr = socket.parse().expect("socket should be valid IP:Port combination.");
 
     if verbose {
-        tracing::info!("Verbose mode");
+        tracing::info!("--verbose flag is deprecated. Set the environment variable `RUST_LOG=pkdns=debug` instead.");
     }
     if cache_ttl != 60 {
         tracing::info!("Set cache-ttl to {cache_ttl}s");
@@ -120,7 +123,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let anydns = Builder::new()
         .handler(MyHandler::new(cache_ttl).await)
-        .verbose(verbose)
         .icann_resolver(forward)
         .listen(socket)
         .build()

--- a/server/src/packet_lookup.rs
+++ b/server/src/packet_lookup.rs
@@ -23,7 +23,7 @@ pub async fn resolve_query<'a>(pkarr_packet: &Packet<'a>, query: &Packet<'a>, so
     reply.answers = pkarr_reply.answers;
     reply.additional_records = pkarr_reply.additional_records;
     reply.name_servers = pkarr_reply.name_servers;
-    tracing::debug!("Built reply with {} answers, {} name servers, and {} additional records.", reply.answers.len(), reply.name_servers.len(), reply.additional_records.len());
+    tracing::debug!("Reply with {} answers.", reply.answers.len());
 
     reply.build_bytes_vec_compressed().unwrap()
 }

--- a/server/src/packet_lookup.rs
+++ b/server/src/packet_lookup.rs
@@ -188,7 +188,7 @@ mod tests {
 
     async fn get_dnssocket() -> DnsSocket {
         let handler = HandlerHolder::new(EmptyHandler::new());
-        DnsSocket::new("127.0.0.1:20384".parse().unwrap(), "8.8.8.8:53".parse().unwrap(), handler, false).await.unwrap()
+        DnsSocket::new("127.0.0.1:20384".parse().unwrap(), "8.8.8.8:53".parse().unwrap(), handler).await.unwrap()
     }
 
     fn example_pkarr_reply() -> (Vec<u8>, PublicKey) {

--- a/server/src/packet_lookup.rs
+++ b/server/src/packet_lookup.rs
@@ -23,6 +23,7 @@ pub async fn resolve_query<'a>(pkarr_packet: &Packet<'a>, query: &Packet<'a>, so
     reply.answers = pkarr_reply.answers;
     reply.additional_records = pkarr_reply.additional_records;
     reply.name_servers = pkarr_reply.name_servers;
+    tracing::debug!("Built reply with {} answers, {} name servers, and {} additional records.", reply.answers.len(), reply.name_servers.len(), reply.additional_records.len());
 
     reply.build_bytes_vec_compressed().unwrap()
 }


### PR DESCRIPTION
This PR improves pkdns logging by adding the `tracing` package.

For most users, nothing changes. The `--verbose` flag makes the output more chatty.

For advanced users, it adds the ability to set the environment variable `RUST_LOG=` to exactly guide pkdns what to log.
This is either done by setting the log level directly (`RUST_LOG=debug`) or by setting the log level for specific modules.

Examples:
- `RUST_LOG=pkdns=trace` will make pkdns very chatty.
- `RUST_LOG=any_dns=trace` will show everything related to ICANN forwarding.
- `RUST_LOG=mainline=debug` will display mainline DHT logs.

These can also be combined: `RUST_LOG=pkdns=trace,any_dns=trace`.

Related #14
