### PR TITLE
fix: respect RUST_LOG in env + advanced logging doc

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,11 @@
             },
             "args": [
             ],
-            "cwd": "${workspaceFolder}"
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "RUST_LOG": "debug"
+                // "RUST_LOG": "pkdns=debug,any_dns=debug,pkarr=debug,mainline=debug"
+            }
         },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Options:
   -V, --version                Print version
 ```
 
+For extended logs, see [here](./docs/logging.md).
+
 ## Announce Your Own Records
 
 Use the `pkdns-cli` to inspect and announce your pkarr records on the Mainline DHT. Download the [latest release](https://github.com/pubky/pkdns/releases/latest/) for your plattform.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,21 @@
+# Logging
+
+By default pkdns stays silent. Use `--verbose` to make pkdns log all queries.
+
+## Advanced
+
+The log output can be adjusted with the environment variable `RUST_LOG`. This is either done by setting the log level directly (`RUST_LOG=debug`) or by setting the log level for specific modules.
+
+Examples:
+
+- `RUST_LOG=pkdns=trace` will make pkdns very chatty.
+- `RUST_LOG=any_dns=trace` will show everything related to ICANN forwarding.
+- `RUST_LOG=mainline=debug` will display mainline DHT logs.
+
+These can also be combined: `RUST_LOG=pkdns=trace,any_dns=trace`.
+
+### Interesting Logs
+
+- `RUST_LOG=pkdns=trace,any_dns=trace` Investigate pkdns/anydns.
+- `RUST_LOG=pkdns=debug,any_dns=debug,pkarr=debug,mainline=debug` Investigate the mainline DHT.
+

--- a/server/src/helpers.rs
+++ b/server/src/helpers.rs
@@ -1,5 +1,5 @@
 use std::env;
-use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use tracing::{Level};
 
 /**
@@ -18,12 +18,18 @@ pub (crate) fn set_full_stacktrace_as_default() -> () {
 
 pub (crate) fn enable_logging(verbose: bool) {
     let key = "RUST_LOG";
-    let is_env_var_set = env::var(key).is_ok();
+    let value = match env::var(key) {
+        Ok(val) => val,
+        Err(_) => "".to_string()
+    };
 
-    if is_env_var_set {
-        tracing_subscriber::fmt().init();
+
+    if value.len() > 0 {
+        tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
+        tracing::info!("Used RUST_LOG={} env variable to set logging output.", value);
+        tracing::debug!("test");
         if verbose {
-            tracing::warn!("Custom RUST_LOG= env variable is set. Ignore --verbose flag.")
+            tracing::warn!("RUST_LOG= is set. Ignore --verbose flag.")
         }
         return
     }


### PR DESCRIPTION
RUST_LOG env variable didnt get respected with #26. This PR fixes this.

It also adds a doc for advanced logging.