### PR TITLE
feat: Improved TTL Caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +321,30 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -347,6 +391,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -479,6 +537,27 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -649,6 +728,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -931,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -978,12 +1063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "litemap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,9 +1092,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 
 [[package]]
 name = "mainline"
@@ -1083,6 +1162,30 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cf62eb4dd975d2dde76432fb1075c49e3ee2331cf36f1f8fd4b66550d32b6f"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener",
+ "futures-util",
+ "once_cell",
+ "parking_lot",
+ "quanta",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid",
 ]
 
 [[package]]
@@ -1178,6 +1281,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1333,13 +1442,14 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "dashmap",
+ "moka",
  "pkarr",
  "rustdns",
  "simple-dns",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "ttl_cache",
  "zbase32",
 ]
 
@@ -1386,6 +1496,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1839,6 +1973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,19 +2173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "ttl_cache"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "typenum"
@@ -2120,6 +2257,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ Other services might occupy the port 53 already. For example, [Docker Desktop](h
 Usage: pkdns [OPTIONS]
 
 Options:
-  -f, --forward <forward>      ICANN fallback DNS server. IP:Port [default: 192.168.1.1:53]
-  -s, --socket <socket>        Socket the server should listen on. IP:Port [default: 0.0.0.0:53]
-  -v, --verbose                Show verbose output.
-      --cache-ttl <cache-ttl>  Pkarr packet cache ttl in seconds.
-      --threads <threads>      Number of threads to process dns queries. [default: 4]
-  -h, --help                   Print help
-  -V, --version                Print version
+  -f, --forward <forward>  ICANN fallback DNS server. IP:Port [default: 8.8.8.8:53]
+  -s, --socket <socket>    Socket the server should listen on. IP:Port [default: 0.0.0.0:53]
+  -v, --verbose            Show verbose output.
+      --min-ttl <min-ttl>  Minimum number of seconds a value is cached for before being refreshed. [default: 300]
+      --max-ttl <max-ttl>  Maximum number of seconds before a cached value gets auto-refreshed. [default: 86400]
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 For extended logs, see [here](./docs/logging.md).
@@ -133,7 +133,7 @@ Use the `pkdns-cli` to inspect and announce your pkarr records on the Mainline D
 ```
 
 
-> ⚠️ The mainline DHT will take some minutes to propagate your changes.
+> ⚠️ pkdns caches DHT packets for at least 5 minutes to improve latency. Run your own instance with `pkdns --max-ttl 0` to disable caching.
 
 ## Limitations
 

--- a/cli/sample/README.md
+++ b/cli/sample/README.md
@@ -7,7 +7,7 @@ This is an example on how to announce your own records on the mainline DHT.
 
 Publish the records by pointing to the seed and zone files.
 
-> ⚠️ The mainline DHT will take some minutes to propagate your changes. In the meantime, pkdns might return a mix of old and new packages. This is normal.
+> ⚠️ pkdns caches DHT packets for at least 5 minutes to improve latency. Run your own instance with `pkdns --max-ttl 0` to disable caching.
 
 ```bash
 $ ./pkdns-cli publish seed.txt pkarr.zone

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,6 @@ ctrlc = "3.4.2"
 simple-dns = "0.6.0"
 pkarr = { version = "2.2.0", features = ["dht", "async", "rand"]}
 zbase32 = "0.1.2"
-ttl_cache = "0.5.1"
 clap = "4.4.18"
 any-dns = "0.3.2"
 chrono = "0.4.33"
@@ -20,3 +19,6 @@ anyhow = "1.0.79"
 tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.18", features = ["smallvec", "fmt", "ansi", "tracing-log", "std", "env-filter"]}
 rustdns = "0.4.0"
+moka = { version = "0.12.8", features = ["future"] }
+dashmap = "6.1.0"
+

--- a/server/src/bootstrap_nodes.rs
+++ b/server/src/bootstrap_nodes.rs
@@ -110,8 +110,8 @@ impl MainlineBootstrapResolver {
         }
     }
 
-    pub fn get_addrs(dns_server: SocketAddr) -> Result<Vec<String>, anyhow::Error> {
-        let resolver = MainlineBootstrapResolver::new(dns_server).unwrap();
+    pub fn get_addrs(dns_server: &SocketAddr) -> Result<Vec<String>, anyhow::Error> {
+        let resolver = MainlineBootstrapResolver::new(dns_server.clone()).unwrap();
         let addrs = resolver.get_bootstrap_nodes()?;
         let addrs: Vec<String> = addrs.into_iter().map(|addr| addr.to_string()).collect();
         Ok(addrs)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,9 +17,9 @@ struct MyHandler {
 }
 
 impl MyHandler {
-    pub async fn new(max_cache_ttl: u64, forward_dns_server: SocketAddr) -> Self {
+    pub async fn new(forward_dns_server: SocketAddr) -> Self {
         Self {
-            pkarr: PkarrResolver::new(max_cache_ttl, Some(forward_dns_server)).await,
+            pkarr: PkarrResolver::new(Some(forward_dns_server)).await,
         }
     }
 }
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .num_args(0)
                 .help("Show verbose output."),
         )
-        .arg(
+        .arg( // TODO: Unused, remove or add deprecated warning.
             clap::Arg::new("cache-ttl")
                 .long("cache-ttl")
                 .required(false)
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }));
 
     let anydns = Builder::new()
-        .handler(MyHandler::new(cache_ttl, forward.clone()).await)
+        .handler(MyHandler::new(forward.clone()).await)
         .icann_resolver(forward)
         .listen(socket)
         .build()

--- a/server/src/pkarr_cache.rs
+++ b/server/src/pkarr_cache.rs
@@ -66,6 +66,7 @@ impl CacheItem {
         }
     }
 
+    #[allow(dead_code)]
     pub fn is_packet(&self) -> bool {
         if let CacheItem::Packet {
             packet: _,
@@ -279,10 +280,12 @@ impl PkarrPacketLruCache {
     /**
      * Approximated size of the cache in bytes. May not be 100% accurate due to pending counts.
      */
+    #[allow(dead_code)]
     pub fn approx_size_bytes(&self) -> u64 {
         self.cache.weighted_size()
     }
-
+    
+    #[allow(dead_code)]
     pub fn entry_count(&self) -> u64 {
         self.cache.entry_count()
     }

--- a/server/src/pkarr_cache.rs
+++ b/server/src/pkarr_cache.rs
@@ -1,54 +1,218 @@
-use std::{sync::Arc, time::Duration};
+use std::{time::{SystemTime, UNIX_EPOCH}};
 
-use pkarr::{dns::Packet, PublicKey};
 
-use tokio::sync::Mutex;
-use ttl_cache::TtlCache;
+use moka::future::Cache;
+use pkarr::{PublicKey, SignedPacket};
+
 
 /**
- * Pkarr record ttl cache
+ * Goal1: Cache things as long as possible to make any attack on the DHT unfeasible.
+ * Goal2: Prevent attackers from overflowing the cache and evict values this way.
  */
-#[derive(Clone)]
-pub struct PkarrPacketTtlCache {
-    max_cache_ttl: u64,
-    cache: Arc<Mutex<TtlCache<String, Vec<u8>>>>
+
+
+
+
+const DEFAULT_MIN_TTL: u64 = 60;
+
+/**
+ * Signed Packet that's cached.
+ */
+#[derive(Clone, Debug)]
+pub struct CachedSignedPacket {
+    pub packet: SignedPacket,
+    /**
+     * When the packet got added to the cache. Seconds timestamp since UNIX_EPOCH.
+     */
+    pub cached_at: u64
 }
 
-impl PkarrPacketTtlCache {
-    pub async fn new(max_cache_ttl: u64) -> Self {
-        PkarrPacketTtlCache {
-            max_cache_ttl,
-            cache: Arc::new(Mutex::new(TtlCache::new(100_000))) // 1 pkarr packet is max 1KB. Therefore 100,000KB = 100MB
+impl CachedSignedPacket {
+    pub fn new(packet: SignedPacket) -> Self {
+        let start = SystemTime::now();
+        let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+
+        Self {
+            packet,
+            cached_at: since_the_epoch.as_secs() as u64
+        }
+    }
+
+    /**
+     * Lowest ttl of any anwser in seconds. Used to determine when to update the cache.
+     */
+    pub fn lowest_answer_ttl(&self) -> Option<u64> {
+         self.packet.packet().answers.iter().map(|answer| answer.ttl as u64).min()
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        self.packet.public_key()
+    }
+
+    /**
+     * Size of the cached value in the memory.
+     */
+    pub fn memory_size(&self) -> usize {
+        self.packet.as_bytes().len() // Not 100% correct because it missed the other values in this struct. Close enough though.
+    }
+
+    /**
+     * If this value is outdated and should be refreshed
+     */
+    pub fn is_ttl_expired(&self) -> bool {
+        self.ttl_expires_in_s() == 0
+    }
+
+    /**
+     * When the smallest ttl expires in seconds.
+     */
+    pub fn ttl_expires_in_s(&self) -> u64 {
+        let min_ttl = self.lowest_answer_ttl().map(|val| {
+            if val < DEFAULT_MIN_TTL {
+                DEFAULT_MIN_TTL
+            } else {
+                val
+            }
+        }).unwrap_or(DEFAULT_MIN_TTL);
+
+        let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs();
+
+        let age_seconds = now - self.cached_at;
+        if age_seconds > min_ttl {
+            0
+        } else {
+            min_ttl - age_seconds
+        }
+    }
+
+}
+
+
+/**
+ * Pkarr record LRU cache.
+ */
+#[derive(Clone, Debug)]
+pub struct PkarrPacketLruCache {
+    cache: Cache<PublicKey, CachedSignedPacket>
+}
+
+impl PkarrPacketLruCache {
+    pub fn new(cache_size_mb: Option<u64>) -> Self {
+        let cache_size_mb = cache_size_mb.unwrap_or(100); // 100MB by default
+        PkarrPacketLruCache {
+            cache: Cache::builder()
+            .weigher(|_key, value: &CachedSignedPacket| -> u32 {
+               value.memory_size() as u32
+            })
+            .max_capacity(cache_size_mb * 1024*1024).build()
         }
     }
 
     /**
      * Adds packet and caches it for the ttl the least long lived answer is valid for.
      */
-    pub async fn add(&mut self, pubkey: PublicKey, reply: Vec<u8>) {
-        let default_ttl = 1200;
-        let packet = Packet::parse(&reply).unwrap();
-        let min_ttl = packet
-            .answers
-            .iter()
-            .map(|answer| answer.ttl)
-            .min()
-            .unwrap_or(default_ttl) as u64;
+    pub async fn add(&mut self, packet: SignedPacket) -> CachedSignedPacket {
+        if let Some(cached) = self.get(&packet.public_key()).await {
+            let new_packet_is_older = cached.packet.timestamp() > packet.timestamp();
+            if new_packet_is_older {
+                // Existing packet is newer than already cached one. Don't update cache. Return existing one.
+                return cached
+            }
+        };
 
-        let ttl = 60.max(min_ttl); // At least 1min
-        let ttl = ttl.min(self.max_cache_ttl);
-        let ttl = Duration::from_secs(ttl as u64);
-
-        let mut cache = self.cache.lock().await;
-        cache.insert(pubkey.to_z32(), reply, ttl);
+        let element = CachedSignedPacket::new(packet);
+        self.cache.insert(element.public_key(), element.clone()).await;
+        element
     }
 
     /**
      * Get packet
      */
-    pub async fn get(&self, pubkey: &PublicKey) -> Option<Vec<u8>> {
-        let z32 = pubkey.to_z32();
-        let cache = self.cache.lock().await;
-        cache.get(&z32).map(|value| value.clone())
+    pub async fn get(&self, pubkey: &PublicKey) -> Option<CachedSignedPacket> {
+        let value = self.cache.get(pubkey).await;
+        value
     }
+
+    /**
+     * Approximated size of the cache in bytes. May not be 100% accurate due to pending counts.
+     */
+    pub fn approx_size_bytes(&self) -> u64 {
+        self.cache.weighted_size()
+    }
+
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use pkarr::{dns::{Name, Packet, ResourceRecord}, Keypair, SignedPacket};
+
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn example_signed_packet() -> SignedPacket {
+        let keypair = Keypair::random();
+        // let uri = keypair.to_uri_string();
+        // println!("Publish packet with pubkey {}", uri);
+
+        let mut packet = Packet::new_reply(0);
+        let ip: Ipv4Addr = "93.184.216.34".parse().unwrap();
+        let record = ResourceRecord::new(
+            Name::new("pknames.p2p").unwrap(),
+            pkarr::dns::CLASS::IN,
+            100,
+            pkarr::dns::rdata::RData::A(ip.try_into().unwrap()),
+        );
+        packet.answers.push(record);
+        let record = ResourceRecord::new(
+            Name::new(".").unwrap(),
+            pkarr::dns::CLASS::IN,
+            100,
+            pkarr::dns::rdata::RData::A(ip.try_into().unwrap()),
+        );
+        packet.answers.push(record);
+        SignedPacket::from_packet(&keypair, &packet).unwrap()
+    }
+
+    #[tokio::test]
+    async fn packet_memory_size() {
+        let packet = example_signed_packet();
+        let cached = CachedSignedPacket::new(packet.clone());
+        assert_eq!(cached.memory_size(), 212); 
+    }
+
+    #[tokio::test]
+    async fn cache_size() {
+        let mut cache = PkarrPacketLruCache::new(Some(1));
+        assert_eq!(cache.approx_size_bytes(), 0);
+
+        for _ in 0..10 {
+            cache.add(example_signed_packet()).await;
+        }
+        cache.cache.run_pending_tasks().await;
+        assert_eq!(cache.approx_size_bytes(), 2120);
+    }
+
+    #[tokio::test]
+    async fn insert_get() {
+        let mut cache = PkarrPacketLruCache::new(Some(1));
+        let packet = example_signed_packet();
+        cache.add(packet.clone()).await;
+
+        for _ in 0..10 {
+            cache.add(example_signed_packet()).await;
+        };
+
+        let recalled = cache.get(&packet.public_key()).await.expect("Value must be in cache");
+        assert_eq!(recalled.public_key(), packet.public_key());
+    }
+
 }

--- a/server/src/pkarr_cache.rs
+++ b/server/src/pkarr_cache.rs
@@ -1,61 +1,176 @@
-use std::{time::{SystemTime, UNIX_EPOCH}};
-
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use moka::future::Cache;
 use pkarr::{PublicKey, SignedPacket};
-
 
 /**
  * Goal1: Cache things as long as possible to make any attack on the DHT unfeasible.
  * Goal2: Prevent attackers from overflowing the cache and evict values this way.
  */
 
-
-
-
 const DEFAULT_MIN_TTL: u64 = 60;
 
 /**
- * Signed Packet that's cached.
+ * Timestamp in seconds since UNIX_EPOCH
  */
-#[derive(Clone, Debug)]
-pub struct CachedSignedPacket {
-    pub packet: SignedPacket,
-    /**
-     * When the packet got added to the cache. Seconds timestamp since UNIX_EPOCH.
-     */
-    pub cached_at: u64
+fn get_timestamp_seconds() -> u64 {
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    since_the_epoch.as_secs() as u64
 }
 
-impl CachedSignedPacket {
-    pub fn new(packet: SignedPacket) -> Self {
-        let start = SystemTime::now();
-        let since_the_epoch = start
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards");
+/**
+ * Caches pkarr packets and not found pkarr packets.
+ * Not found is important to avoid calling the DHT over and over again.
+ */
+#[derive(Clone, Debug)]
+pub enum CacheItem {
+    NotFound {
+        public_key: PublicKey,
+        /**
+         * When the packet got added to the cache or cache got updated. Seconds timestamp since UNIX_EPOCH.
+         */
+        cached_at: u64,
+    },
+    Packet {
+        packet: SignedPacket,
+        /**
+         * When the packet got added to the cache or cache got updated. Seconds timestamp since UNIX_EPOCH.
+         */
+        cached_at: u64,
+    },
+}
 
-        Self {
-            packet,
-            cached_at: since_the_epoch.as_secs() as u64
+impl CacheItem {
+    pub fn new_packet(packet: SignedPacket) -> Self {
+        Self::Packet {
+            packet: packet,
+            cached_at: get_timestamp_seconds(),
+        }
+    }
+
+    pub fn new_not_found(pubkey: PublicKey) -> Self {
+        Self::NotFound {
+            public_key: pubkey,
+            cached_at: get_timestamp_seconds(),
+        }
+    }
+
+    pub fn is_not_found(&self) -> bool {
+        if let CacheItem::NotFound {
+            public_key: _,
+            cached_at: _,
+        } = self
+        {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_packet(&self) -> bool {
+        if let CacheItem::Packet {
+            packet: _,
+            cached_at: _,
+        } = self
+        {
+            true
+        } else {
+            false
+        }
+    }
+
+    /**
+     * Returns signed packet. Panics if not found.
+     */
+    pub fn unwrap(self) -> SignedPacket {
+        if let CacheItem::Packet { packet, cached_at: _ } = self {
+            return packet;
+        } else {
+            panic!("Can not unwrap CacheItem without a packet.")
+        }
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        match self {
+            CacheItem::NotFound {
+                public_key,
+                cached_at: _,
+            } => public_key.clone(),
+            CacheItem::Packet { packet, cached_at: _ } => packet.public_key(),
+        }
+    }
+
+    /**
+     * Updates the cached_at timestamp to now.
+     */
+    pub fn refresh_cached_at(&mut self) {
+        match self {
+            CacheItem::NotFound {
+                public_key: _,
+                cached_at,
+            } => {
+                *cached_at = get_timestamp_seconds();
+            }
+            CacheItem::Packet { packet: _, cached_at } => {
+                *cached_at = get_timestamp_seconds();
+            }
+        }
+    }
+
+    /**
+     * Timestamp given by the controller of the keypair. Basically a version number of the packet.
+     * NotFound items always have a timestamp of 0.
+     */
+    pub fn controller_timestamp(&self) -> u64 {
+        match self {
+            CacheItem::NotFound {
+                public_key: _,
+                cached_at: _,
+            } => 0,
+            CacheItem::Packet { packet, cached_at: _ } => packet.timestamp(),
+        }
+    }
+
+    fn cached_at(&self) -> u64 {
+        match self {
+            CacheItem::NotFound {
+                public_key: _,
+                cached_at,
+            } => cached_at.clone(),
+            CacheItem::Packet { packet: _, cached_at } => cached_at.clone(),
         }
     }
 
     /**
      * Lowest ttl of any anwser in seconds. Used to determine when to update the cache.
+     * NotFound or packet with now answeres => None.
      */
-    pub fn lowest_answer_ttl(&self) -> Option<u64> {
-         self.packet.packet().answers.iter().map(|answer| answer.ttl as u64).min()
-    }
-
-    pub fn public_key(&self) -> PublicKey {
-        self.packet.public_key()
+    fn lowest_answer_ttl(&self) -> Option<u64> {
+        match self {
+            CacheItem::NotFound {
+                public_key: _,
+                cached_at: _,
+            } => None,
+            CacheItem::Packet { packet, cached_at: _ } => {
+                packet.packet().answers.iter().map(|answer| answer.ttl as u64).min()
+            }
+        }
     }
 
     /**
      * Size of the cached value in the memory.
      */
     pub fn memory_size(&self) -> usize {
-        self.packet.as_bytes().len() // Not 100% correct because it missed the other values in this struct. Close enough though.
+        match self {
+            CacheItem::NotFound {
+                public_key: _,
+                cached_at: _,
+            } => {
+                32 + 8 // Public key 32 + cached_at 8
+            }
+            CacheItem::Packet { packet, cached_at: _ } => packet.as_bytes().len() + 8,
+        }
     }
 
     /**
@@ -69,36 +184,31 @@ impl CachedSignedPacket {
      * When the smallest ttl expires in seconds.
      */
     pub fn ttl_expires_in_s(&self) -> u64 {
-        let min_ttl = self.lowest_answer_ttl().map(|val| {
-            if val < DEFAULT_MIN_TTL {
-                DEFAULT_MIN_TTL
-            } else {
-                val
-            }
-        }).unwrap_or(DEFAULT_MIN_TTL);
+        let min_ttl = self
+            .lowest_answer_ttl()
+            .map(|val| if val < DEFAULT_MIN_TTL { DEFAULT_MIN_TTL } else { val })
+            .unwrap_or(DEFAULT_MIN_TTL);
 
         let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs();
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
 
-        let age_seconds = now - self.cached_at;
+        let age_seconds = now - self.cached_at();
         if age_seconds > min_ttl {
             0
         } else {
             min_ttl - age_seconds
         }
     }
-
 }
 
-
 /**
- * Pkarr record LRU cache.
+ * LRU cache for packets.
  */
 #[derive(Clone, Debug)]
 pub struct PkarrPacketLruCache {
-    cache: Cache<PublicKey, CachedSignedPacket>
+    cache: Cache<PublicKey, CacheItem>, // Moka Cache is thread safe
 }
 
 impl PkarrPacketLruCache {
@@ -106,34 +216,59 @@ impl PkarrPacketLruCache {
         let cache_size_mb = cache_size_mb.unwrap_or(100); // 100MB by default
         PkarrPacketLruCache {
             cache: Cache::builder()
-            .weigher(|_key, value: &CachedSignedPacket| -> u32 {
-               value.memory_size() as u32
-            })
-            .max_capacity(cache_size_mb * 1024*1024).build()
+                .weigher(|_key, value: &CacheItem| -> u32 { value.memory_size() as u32 })
+                .max_capacity(cache_size_mb * 1024 * 1024)
+                .build(),
         }
     }
 
     /**
-     * Adds packet and caches it for the ttl the least long lived answer is valid for.
+     * Adds a new item to the cache. Makes sure that older items do not override newer items.
      */
-    pub async fn add(&mut self, packet: SignedPacket) -> CachedSignedPacket {
-        if let Some(cached) = self.get(&packet.public_key()).await {
-            let new_packet_is_older = cached.packet.timestamp() > packet.timestamp();
+    async fn add(&mut self, new_item: CacheItem) -> CacheItem {
+        if let Some(mut already_cached) = self.get(&new_item.public_key()).await {
+            // Already in cache
+            let same_age = new_item.controller_timestamp() == already_cached.controller_timestamp();
+            if same_age {
+                // Update cached_at timestamp
+                already_cached.refresh_cached_at();
+                self.cache
+                    .insert(already_cached.public_key(), already_cached.clone())
+                    .await;
+                return already_cached;
+            }
+
+            let new_packet_is_older = new_item.controller_timestamp() < already_cached.controller_timestamp();
             if new_packet_is_older {
                 // Existing packet is newer than already cached one. Don't update cache. Return existing one.
-                return cached
+                return already_cached;
             }
         };
 
-        let element = CachedSignedPacket::new(packet);
-        self.cache.insert(element.public_key(), element.clone()).await;
-        element
+        self.cache.insert(new_item.public_key(), new_item.clone()).await;
+        new_item
+    }
+
+    /**
+     * Adds packet. Makes sure to not override newer instances in the cache.
+     */
+    pub async fn add_packet(&mut self, packet: SignedPacket) -> CacheItem {
+        let new_item = CacheItem::new_packet(packet);
+        self.add(new_item).await
+    }
+
+    /**
+     * Adds not found. Makes sure to not override newer instances in the cache.
+     */
+    pub async fn add_not_found(&mut self, pubkey: PublicKey) -> CacheItem {
+        let new_item = CacheItem::new_not_found(pubkey);
+        self.add(new_item).await
     }
 
     /**
      * Get packet
      */
-    pub async fn get(&self, pubkey: &PublicKey) -> Option<CachedSignedPacket> {
+    pub async fn get(&self, pubkey: &PublicKey) -> Option<CacheItem> {
         let value = self.cache.get(pubkey).await;
         value
     }
@@ -150,19 +285,17 @@ impl PkarrPacketLruCache {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use pkarr::{dns::{Name, Packet, ResourceRecord}, Keypair, SignedPacket};
+    use pkarr::{
+        dns::{Name, Packet, ResourceRecord},
+        Keypair, SignedPacket,
+    };
 
     use super::*;
     use std::net::Ipv4Addr;
 
-    fn example_signed_packet() -> SignedPacket {
-        let keypair = Keypair::random();
-        // let uri = keypair.to_uri_string();
-        // println!("Publish packet with pubkey {}", uri);
-
+    fn example_signed_packet(keypair: Keypair) -> SignedPacket {
         let mut packet = Packet::new_reply(0);
         let ip: Ipv4Addr = "93.184.216.34".parse().unwrap();
         let record = ResourceRecord::new(
@@ -184,9 +317,9 @@ mod tests {
 
     #[tokio::test]
     async fn packet_memory_size() {
-        let packet = example_signed_packet();
-        let cached = CachedSignedPacket::new(packet.clone());
-        assert_eq!(cached.memory_size(), 212); 
+        let packet = example_signed_packet(Keypair::random());
+        let cached = CacheItem::new_packet(packet.clone());
+        assert_eq!(cached.memory_size(), 212);
     }
 
     #[tokio::test]
@@ -195,7 +328,7 @@ mod tests {
         assert_eq!(cache.approx_size_bytes(), 0);
 
         for _ in 0..10 {
-            cache.add(example_signed_packet()).await;
+            cache.add_packet(example_signed_packet(Keypair::random())).await;
         }
         cache.cache.run_pending_tasks().await;
         assert_eq!(cache.approx_size_bytes(), 2120);
@@ -204,15 +337,68 @@ mod tests {
     #[tokio::test]
     async fn insert_get() {
         let mut cache = PkarrPacketLruCache::new(Some(1));
-        let packet = example_signed_packet();
-        cache.add(packet.clone()).await;
+        let packet = example_signed_packet(Keypair::random());
+        cache.add_packet(packet.clone()).await;
 
         for _ in 0..10 {
-            cache.add(example_signed_packet()).await;
-        };
+            cache.add_packet(example_signed_packet(Keypair::random())).await;
+        }
 
         let recalled = cache.get(&packet.public_key()).await.expect("Value must be in cache");
         assert_eq!(recalled.public_key(), packet.public_key());
     }
+
+    #[tokio::test]
+    async fn override_old_cached_packet() {
+        let mut cache = PkarrPacketLruCache::new(Some(1));
+        let key = Keypair::random();
+        let packet1 = example_signed_packet(key.clone());
+        let packet2 = example_signed_packet(key.clone());
+        assert_ne!(packet1.timestamp(), packet2.timestamp());
+
+        cache.add_packet(packet1.clone()).await;
+        cache.add_packet(packet2.clone()).await;
+        let cached = cache.get(&key.public_key()).await.unwrap();
+        assert_eq!(packet2.timestamp(), cached.controller_timestamp());
+    }
+
+    #[tokio::test]
+    async fn keep_newer_cached_packet() {
+        let mut cache = PkarrPacketLruCache::new(Some(1));
+        let key = Keypair::random();
+        let packet1 = example_signed_packet(key.clone());
+        let packet2 = example_signed_packet(key.clone());
+        assert_ne!(packet1.timestamp(), packet2.timestamp());
+
+        cache.add_packet(packet2.clone()).await;
+        cache.add_packet(packet1.clone()).await;
+        let cached = cache.get(&key.public_key()).await.unwrap();
+        assert_eq!(packet2.timestamp(), cached.controller_timestamp());
+    }
+
+    #[tokio::test]
+    async fn override_old_not_found_cached_packet() {
+        let mut cache = PkarrPacketLruCache::new(Some(1));
+        let key = Keypair::random();
+        let packet1 = example_signed_packet(key.clone());
+        cache.add(CacheItem::new_not_found(key.public_key())).await;
+        let cached = cache.get(&key.public_key()).await.unwrap();
+        assert_eq!(cached.controller_timestamp(), 0);
+        cache.add_packet(packet1.clone()).await;
+        let cached = cache.get(&key.public_key()).await.unwrap();
+        assert_eq!(packet1.timestamp(), cached.controller_timestamp());
+    }
+
+    #[tokio::test]
+    async fn not_found_not_overriding_cached_packet() {
+        let mut cache = PkarrPacketLruCache::new(Some(1));
+        let key = Keypair::random();
+        let packet1 = example_signed_packet(key.clone());
+        cache.add_packet(packet1.clone()).await;
+        cache.add(CacheItem::new_not_found(key.public_key())).await;
+        let cached = cache.get(&key.public_key()).await.unwrap();
+        assert_eq!(packet1.timestamp(), cached.controller_timestamp());
+    }
+
 
 }


### PR DESCRIPTION
So far, pkarr packets got cached for 60s and then discarded. This PR changes the following:

- Adds a LRU cache. Packets never get evicted as long there is space in the cache.
- Respects the packet TTL. The packet TTL is the lowest ttl of any entry.
- Added `--min-ttl` (default 5min), `--max-ttl` (default 24hrs), and `--cache-mb` (default 100MB) options to control cache behaviour. 

**Resilience** TTLs don't lead to cache eviction but is a sign that the server needs to refresh the cache. In case the packet is not found on the DHT anymore, the cached value is still kept alive. In case the fetched DHT value is older than the cached value, the newer cached value is kept.

**Deprecations** `--cache-ttl` and `--threads <threads>` were removed.

Solves #19 