### PR TITLE
fix: bad dht resolution when updating values

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,5 +29,29 @@
                 // "RUST_LOG": "pkdns=debug,any_dns=debug,pkarr=debug,mainline=debug"
             }
         },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "CLI Publish",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=pkdns-cli",
+                    "--package=pkdns-cli"
+                ],
+                "filter": {
+                    "name": "pkdns-cli",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "publish", "./cli/sample/seed.txt", "./cli/sample/pkarr.zone", "--once"
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                // "RUST_LOG": "debug"
+                // "RUST_LOG": "pkdns=debug,any_dns=debug,pkarr=debug,mainline=debug"
+            }
+        },
     ]
 }

--- a/cli/src/commands/resolve.rs
+++ b/cli/src/commands/resolve.rs
@@ -1,13 +1,17 @@
+use std::{thread, time::Duration};
+
 use chrono::{DateTime, Utc};
 use clap::ArgMatches;
-use pkarr::{PkarrClient, PublicKey, Settings};
+use pkarr::PublicKey;
 
-use crate::pkarr_packet::PkarrPacket;
+use crate::{helpers::construct_pkarr_client, pkarr_packet::PkarrPacket};
 
 
 fn resolve_pkarr(uri: &str) -> (PkarrPacket, DateTime<Utc>)  {
-    let client = PkarrClient::new(Settings::default()).unwrap();
+    let client = construct_pkarr_client();
     let pubkey: PublicKey = uri.try_into().expect("Should be valid pkarr public key.");
+    let _ = client.resolve(&pubkey);
+    thread::sleep(Duration::from_millis(500));
     let res = client.resolve(&pubkey);
     if let Err(e) = res {
         eprintln!("Failed to resolve. {e}");

--- a/cli/src/helpers.rs
+++ b/cli/src/helpers.rs
@@ -1,0 +1,10 @@
+use pkarr::{PkarrClient, PkarrClientBuilder};
+
+
+/// Construct new pkarr client with no cache, no resolver, only DHT
+pub fn construct_pkarr_client() -> PkarrClient  {
+    PkarrClientBuilder::default()
+    // .maximum_ttl(0)
+    .resolvers(None)
+    .build().unwrap()
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ mod simple_zone;
 mod pkarr_packet;
 mod pkarr_publisher;
 mod commands;
+mod helpers;
 
 
 #[tokio::main]

--- a/cli/src/pkarr_publisher.rs
+++ b/cli/src/pkarr_publisher.rs
@@ -2,6 +2,8 @@ use std::{sync::mpsc::channel, io::{self, Write}};
 use chrono;
 use pkarr::{PkarrClient, Settings, SignedPacket};
 
+use crate::helpers::construct_pkarr_client;
+
 pub struct PkarrPublisher {
     pub packet: SignedPacket
 }
@@ -17,7 +19,7 @@ impl PkarrPublisher {
     }
     
     pub fn run_once(&self) -> () {
-        let client = PkarrClient::new(Settings::default()).unwrap();
+        let client = construct_pkarr_client();
         print!("Hang on...");
         io::stdout().flush().unwrap();
         let result = client.publish(&self.packet);

--- a/server/src/pkarr_resolver.rs
+++ b/server/src/pkarr_resolver.rs
@@ -159,6 +159,7 @@ impl PkarrResolver {
             .minimum_ttl(0)
             .maximum_ttl(0) // Disable Pkarr caching
             .dht_settings(dht_settings) // Use resolved bootstrap node
+            .resolvers(None)
             .build()
             .unwrap();
         let limiter = RateLimiterBuilder::new().max_per_second(settings.max_dht_queries_per_ip_per_second.clone());


### PR DESCRIPTION
Removes resolver from PKDNS because they lead to bad performance when updating values on the DHT. Might re-add later but the current state is unbearable.