### PR TITLE
chore: reduce min-ttl to 60s

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             clap::Arg::new("min-ttl")
                 .long("min-ttl")
                 .required(false)
-                .default_value("300")
+                .default_value("60")
                 .help("Minimum number of seconds a value is cached for before being refreshed."),
         )
         .arg(


### PR DESCRIPTION
Reduces min ttl from 300s (5min) to 60s so devs can debug their apps better.