### PR TITLE
feat: {external_ipv4} and {external_ipv6} variables (DynDNS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,7 +861,7 @@ dependencies = [
  "env_logger",
  "failure",
  "log",
- "reqwest",
+ "reqwest 0.9.24",
  "trust-dns",
  "trust-dns-proto",
 ]
@@ -1306,6 +1312,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.9.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio 1.42.0",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1565,7 @@ dependencies = [
  "bytes 1.9.0",
  "futures-channel",
  "futures-util",
+ "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -1560,11 +1586,28 @@ dependencies = [
  "futures 0.3.30",
  "hyper 0.14.31",
  "log",
- "rustls",
+ "rustls 0.19.1",
  "tokio 1.42.0",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "webpki",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http 1.2.0",
+ "hyper 1.5.2",
+ "hyper-util",
+ "rustls 0.23.20",
+ "rustls-pki-types",
+ "tokio 1.42.0",
+ "tokio-rustls 0.26.1",
+ "tower-service",
 ]
 
 [[package]]
@@ -1578,6 +1621,22 @@ dependencies = [
  "hyper 0.12.36",
  "native-tls",
  "tokio-io",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes 1.9.0",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "native-tls",
+ "tokio 1.42.0",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1811,6 +1870,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2527,6 +2592,8 @@ dependencies = [
  "ctrlc",
  "domain",
  "pkarr",
+ "rand 0.8.5",
+ "reqwest 0.12.10",
  "serde",
  "shellexpand",
  "thiserror",
@@ -2882,7 +2949,7 @@ dependencies = [
  "futures 0.1.31",
  "http 0.1.21",
  "hyper 0.12.36",
- "hyper-tls",
+ "hyper-tls 0.3.2",
  "log",
  "mime",
  "mime_guess",
@@ -2899,6 +2966,50 @@ dependencies = [
  "url 1.7.2",
  "uuid 0.7.4",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3536321cfc54baa8cf3e273d5e1f63f889067829c4b410fcdbac8ca7b80994"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.9.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding 2.3.1",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.1",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio 1.42.0",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url 2.5.3",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2921,9 +3032,24 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3021,9 +3147,48 @@ checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
  "log",
- "ring",
+ "ring 0.16.20",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3059,8 +3224,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -3423,6 +3588,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3445,6 +3613,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.91",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3690,6 +3879,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio 1.42.0",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,9 +3913,19 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio 1.42.0",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls 0.23.20",
+ "tokio 1.42.0",
 ]
 
 [[package]]
@@ -4046,6 +4255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,8 +4450,8 @@ version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4297,6 +4512,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "domain"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eefe29e8dd614abbee51a1616654cab123c4c56850ab83f5b7f1e1f9977bf7c"
+checksum = "64008666d9f3b6a88a63cd28ad8f3a5a859b8037e11bfb680c1b24945ea1c28d"
 dependencies = [
  "bytes 1.9.0",
  "octseq",
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "octseq"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed2eaec452d98ccc1c615dd843fd039d9445f2fb4da114ee7e6af5fcb68be98"
+checksum = "126c3ca37c9c44cec575247f43a3e4374d8927684f129d2beeb0d2cef262fe12"
 dependencies = [
  "bytes 1.9.0",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1.0.49"
 serde = { version = "1.0.199", features = ["derive"] }
 clap = { version = "4.5.1", features = ["derive"] }
 pkarr = { version = "2.2.1", features = ["dht", "async", "rand"]}
-domain = {version = "0.10.1", features = ["zonefile", "bytes"]}
+domain = {version = "0.10.3", features = ["zonefile", "bytes"]}
 bytes = "1.7.1"
 chrono = "0.4.38"
 shellexpand = "3.1.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,3 +19,5 @@ chrono = "0.4.38"
 shellexpand = "3.1.0"
 zbase32 = "0.1.2"
 ctrlc = "3.4.4"
+reqwest = { version="0.12.10", features = ["json"]}
+rand = {version = "0.8"}

--- a/cli/sample/pkarr.zone
+++ b/cli/sample/pkarr.zone
@@ -5,6 +5,6 @@ $TTL 300
 @    IN	  MX	20	mail2.example.com.   
 
 @    IN    A      127.0.0.1
-sub  IN    A      127.0.0.1
+subv4  IN    A      {external_ipv4}
 
 text  IN   TXT    hero=satoshi

--- a/cli/sample/pkarr.zone
+++ b/cli/sample/pkarr.zone
@@ -5,6 +5,9 @@ $TTL 300
 @    IN	  MX	20	mail2.example.com.   
 
 @    IN    A      127.0.0.1
+; The variable {external_ipv4} is replaced with your external IPv4 address.
 subv4  IN    A      {external_ipv4}
+; The variable {external_ipv6} is replaced with your external IPv6 address.
+subv4  IN    AAAA      {external_ipv6}
 
 text  IN   TXT    hero=satoshi

--- a/cli/sample/pkarr.zone
+++ b/cli/sample/pkarr.zone
@@ -5,9 +5,7 @@ $TTL 300
 @    IN	  MX	20	mail2.example.com.   
 
 @    IN    A      127.0.0.1
-; The variable {external_ipv4} is replaced with your external IPv4 address.
 subv4  IN    A      {external_ipv4}
-; The variable {external_ipv6} is replaced with your external IPv6 address.
 subv4  IN    AAAA      {external_ipv6}
 
 text  IN   TXT    hero=satoshi

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -27,15 +27,14 @@ async fn fill_dyndns_variables(zone: &mut String) -> Result<(), anyhow::Error> {
         *zone = zone.replace("{external_ipv4}", &external_ipv4.to_string());
     };
 
-    // TODO: IPv6 not supported by the Zone loader yet.
-    // if zone.contains("{external_ipv6}") {
-    //     let ip_result = resolve_ipv6().await;
-    //     if let Err(e) = ip_result {
-    //         return Err(anyhow!(e));
-    //     }
-    //     let (external_ipv6, provider_name) = ip_result.unwrap();
-    //     *zone = zone.replace("{external_ipv6}", &external_ipv6.to_string());
-    // };
+    if zone.contains("{external_ipv6}") {
+        let ip_result = resolve_ipv6().await;
+        if let Err(e) = ip_result {
+            return Err(anyhow!(e));
+        }
+        let (external_ipv6, _) = ip_result.unwrap();
+        *zone = zone.replace("{external_ipv6}", &external_ipv6.to_string());
+    };
 
     Ok(())
 }

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -5,8 +5,9 @@ use std::{
 };
 
 use anyhow::anyhow;
+use chrono::Utc;
 use clap::ArgMatches;
-use pkarr::{Keypair, SignedPacket};
+use pkarr::{Keypair, PkarrClient, PublicKey, SignedPacket};
 
 use crate::external_ip::{resolve_ipv4, resolve_ipv6};
 use crate::{helpers::construct_pkarr_client, simple_zone::SimpleZone};
@@ -93,9 +94,36 @@ fn parse_seed(seed: &str) -> Keypair {
     keypair
 }
 
+// /// Determines if the packet on the DHT is different to the new packet
+// fn should_packet_be_refreshed(client: &PkarrClient, pubkey: &PublicKey, new_packet: &SignedPacket) -> bool {
+//     if let Ok(old_packet) = client.resolve(pubkey) {
+//         if let Some(old_packet) = old_packet {
+//             // Check if the packet even changed.
+//             let old_bytes = old_packet.packet().build_bytes_vec().unwrap();
+//             let new_bytes = new_packet.packet().build_bytes_vec().unwrap();
+//             let did_packet_change = old_bytes != new_bytes;
+//             if did_packet_change {
+//                 return true
+//             };
+
+//             // Only refresh a similar page max every 1min to avoid running into
+//             // a rate limit.
+//             let published_at = std::time::UNIX_EPOCH + std::time::Duration::from_micros(old_packet.timestamp());
+//             let datetime: chrono::DateTime<Utc> = published_at.clone().into();
+//             println!("Published at {datetime}");
+//             let age = published_at.elapsed().unwrap();
+//             let is_too_recent = age.as_secs() < 60;
+//             return !is_too_recent;
+//         };
+//     };
+//     // Not found on the DHT.
+//     true
+// }
+
 pub async fn cli_publish(matches: &ArgMatches) {
     let keypair = read_seed_file(matches);
     let pubkey = keypair.to_z32();
+    let client = construct_pkarr_client();
 
     let zone = read_zone_file(matches, &pubkey).await ;
     println!("{}", zone.packet);
@@ -105,10 +133,15 @@ pub async fn cli_publish(matches: &ArgMatches) {
         eprintln!("Failed to sign the pkarr packet. {e}");
         std::process::exit(1);
     }
-
     let packet = packet.unwrap();
 
-    let client = construct_pkarr_client();
+
+    // if !should_packet_be_refreshed(&client, &keypair.public_key(), &packet) {
+    //     println!("Don't publish packet because it did not change and last update was within < 1min.");
+    //     return
+    // };
+
+
     print!("Hang on...");
     std::io::stdout().flush().unwrap();
     let result = client.publish(&packet);

--- a/cli/src/external_ip/mod.rs
+++ b/cli/src/external_ip/mod.rs
@@ -1,0 +1,4 @@
+mod providers;
+mod resolver;
+
+pub use resolver::{resolve_ipv4, resolve_ipv6};

--- a/cli/src/external_ip/providers/external_ip_resolver.rs
+++ b/cli/src/external_ip/providers/external_ip_resolver.rs
@@ -1,0 +1,62 @@
+use std::{future::Future, net::{AddrParseError, Ipv4Addr, Ipv6Addr}, pin::Pin};
+
+use reqwest::IntoUrl;
+
+pub struct ProviderResolver {
+    pub name: String,
+    ipv4: Pin<Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<Ipv4Addr, ExternalIpResolverError>>>>>>,
+    ipv6: Pin<Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<Ipv6Addr, ExternalIpResolverError>>>>>>
+}
+
+impl  ProviderResolver {
+    pub fn new(
+        name: String, 
+        ipv4: Pin<Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<Ipv4Addr, ExternalIpResolverError>>>>>>,
+        ipv6: Pin<Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<Ipv6Addr, ExternalIpResolverError>>>>>>
+    ) -> Self {
+        Self {
+            name,
+            ipv4,
+            ipv6
+        }
+    }
+
+    /// Resolve this computers external ipv4 address.
+    pub async fn ipv4(&self) -> Result<Ipv4Addr, ExternalIpResolverError> {
+        let func = &self.ipv4;
+        func().await
+    }
+
+    /// Resolve this computers external ipv6 address.
+    pub async fn ipv6(&self) -> Result<Ipv6Addr, ExternalIpResolverError> {
+        let func = &self.ipv6;
+        func().await
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExternalIpResolverError {
+    #[error(transparent)]
+    IO(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    IpParse(#[from] AddrParseError),
+}
+
+/// Resolves a url return the Ipv4 in it's response.
+pub async fn resolve_ipv4_with_url<T: IntoUrl>(url: T) -> Result<Ipv4Addr, ExternalIpResolverError> {
+    let response = reqwest::get(url).await?;
+    let text = response.text().await?;
+    let text = text.trim();
+    let ip: Ipv4Addr = text.parse()?;
+    Ok(ip)
+}
+
+/// Resolves a url return the Ipv6 in it's response.
+pub async fn resolve_ipv6_with_url<T: IntoUrl>(url: T) -> Result<Ipv6Addr, ExternalIpResolverError> {
+    let response = reqwest::get(url).await?;
+    let text = response.text().await?;
+    let text = text.trim();
+    let ip: Ipv6Addr = text.parse()?;
+    Ok(ip)
+}

--- a/cli/src/external_ip/providers/icanhazip.rs
+++ b/cli/src/external_ip/providers/icanhazip.rs
@@ -1,0 +1,38 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use super::external_ip_resolver::{
+    resolve_ipv4_with_url, resolve_ipv6_with_url, ExternalIpResolverError, ProviderResolver,
+};
+
+pub async fn resolve_ipv4() -> Result<Ipv4Addr, ExternalIpResolverError> {
+    resolve_ipv4_with_url("https://ipv4.icanhazip.com").await
+}
+
+pub async fn resolve_ipv6() -> Result<Ipv6Addr, ExternalIpResolverError> {
+    resolve_ipv6_with_url("https://ipv6.icanhazip.com").await
+}
+
+pub fn get_resolver() -> ProviderResolver {
+    ProviderResolver::new(
+        "icanhazip.com".to_string(),
+        Box::pin(move || Box::pin(resolve_ipv4())),
+        Box::pin(move || Box::pin(resolve_ipv6())),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ipv4() {
+        let ip = resolve_ipv4().await;
+        assert!(ip.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_ipv6() {
+        let ip = resolve_ipv6().await;
+        assert!(ip.is_ok());
+    }
+}

--- a/cli/src/external_ip/providers/identme.rs
+++ b/cli/src/external_ip/providers/identme.rs
@@ -1,0 +1,38 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use super::external_ip_resolver::{resolve_ipv4_with_url, resolve_ipv6_with_url, ExternalIpResolverError, ProviderResolver};
+
+pub async fn resolve_ipv4() -> Result<Ipv4Addr, ExternalIpResolverError> {
+    resolve_ipv4_with_url("https://v4.ident.me").await
+}
+
+pub async fn resolve_ipv6() -> Result<Ipv6Addr, ExternalIpResolverError> {
+    resolve_ipv6_with_url("https://v6.ident.me").await
+}
+
+
+pub fn get_resolver() -> ProviderResolver {
+    ProviderResolver::new(
+        "ident.me".to_string(),
+        Box::pin(move || Box::pin(resolve_ipv4())),
+        Box::pin(move || Box::pin(resolve_ipv6())),
+    )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ipv4() {
+        let ip = resolve_ipv4().await;
+        assert!(ip.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_ipv6() {
+        let ip = resolve_ipv6().await;
+        assert!(ip.is_ok());
+    }
+}

--- a/cli/src/external_ip/providers/ipifyorg.rs
+++ b/cli/src/external_ip/providers/ipifyorg.rs
@@ -1,0 +1,37 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use super::external_ip_resolver::{resolve_ipv4_with_url, resolve_ipv6_with_url, ExternalIpResolverError, ProviderResolver};
+
+pub async fn resolve_ipv4() -> Result<Ipv4Addr, ExternalIpResolverError> {
+    resolve_ipv4_with_url("https://api.ipify.org").await
+}
+
+pub async fn resolve_ipv6() -> Result<Ipv6Addr, ExternalIpResolverError> {
+    resolve_ipv6_with_url("https://api6.ipify.org").await
+}
+
+
+pub fn get_resolver() -> ProviderResolver {
+    ProviderResolver::new(
+        "ipify.org".to_string(),
+        Box::pin(move || Box::pin(resolve_ipv4())),
+        Box::pin(move || Box::pin(resolve_ipv6())),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ipv4() {
+        let ip = resolve_ipv4().await;
+        assert!(ip.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_ipv6() {
+        let ip = resolve_ipv6().await;
+        assert!(ip.is_ok());
+    }
+}

--- a/cli/src/external_ip/providers/ipinfoio.rs
+++ b/cli/src/external_ip/providers/ipinfoio.rs
@@ -1,0 +1,50 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use serde::Deserialize;
+
+use super::external_ip_resolver::{ExternalIpResolverError, ProviderResolver};
+
+#[derive(Debug, Deserialize)]
+struct IpResponse {
+    pub ip: String,
+}
+
+pub async fn resolve_ipv4() -> Result<Ipv4Addr, ExternalIpResolverError> {
+    let response = reqwest::get("https://ipinfo.io").await?;
+    let text = response.json::<IpResponse>().await?;
+    let ip: Ipv4Addr = text.ip.parse()?;
+    Ok(ip)
+}
+
+pub async fn resolve_ipv6() -> Result<Ipv6Addr, ExternalIpResolverError> {
+    let response = reqwest::get("https://v6.ipinfo.io").await?;
+    let text = response.json::<IpResponse>().await?;
+    let ip: Ipv6Addr = text.ip.parse()?;
+    Ok(ip)
+}
+
+pub fn get_resolver() -> ProviderResolver {
+    ProviderResolver::new(
+        "ipinfo.io".to_string(),
+        Box::pin(move || Box::pin(resolve_ipv4())),
+        Box::pin(move || Box::pin(resolve_ipv6())),
+    )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ipv4() {
+        let ip = resolve_ipv4().await;
+        ip.expect("Valid ipv4");
+    }
+
+    #[tokio::test]
+    async fn test_ipv6() {
+        let ip = resolve_ipv6().await;
+        ip.expect("Valid ipv6");
+    }
+}

--- a/cli/src/external_ip/providers/mod.rs
+++ b/cli/src/external_ip/providers/mod.rs
@@ -1,0 +1,9 @@
+pub mod ipifyorg;
+pub mod ipinfoio;
+pub mod myip;
+pub mod icanhazip;
+pub mod identme;
+
+
+mod external_ip_resolver;
+pub use external_ip_resolver::ProviderResolver;

--- a/cli/src/external_ip/providers/myip.rs
+++ b/cli/src/external_ip/providers/myip.rs
@@ -1,0 +1,50 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use serde::Deserialize;
+
+use super::external_ip_resolver::{ExternalIpResolverError, ProviderResolver};
+
+#[derive(Debug, Deserialize)]
+struct IpResponse {
+    pub ip: String,
+}
+
+pub async fn resolve_ipv4() -> Result<Ipv4Addr, ExternalIpResolverError> {
+    let response = reqwest::get("https://4.myip.is/").await?;
+    let text = response.json::<IpResponse>().await?;
+    let ip: Ipv4Addr = text.ip.parse()?;
+    Ok(ip)
+}
+
+pub async fn resolve_ipv6() -> Result<Ipv6Addr, ExternalIpResolverError> {
+    let response = reqwest::get("https://6.myip.is/").await?;
+    let text = response.json::<IpResponse>().await?;
+    let ip: Ipv6Addr = text.ip.parse()?;
+    Ok(ip)
+}
+
+pub fn get_resolver() -> ProviderResolver {
+    ProviderResolver::new(
+        "myip.is".to_string(),
+        Box::pin(move || Box::pin(resolve_ipv4())),
+        Box::pin(move || Box::pin(resolve_ipv6())),
+    )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ipv4() {
+        let ip = resolve_ipv4().await;
+        ip.expect("Valid ipv4");
+    }
+
+    #[tokio::test]
+    async fn test_ipv6() {
+        let ip = resolve_ipv6().await;
+        ip.expect("Valid ipv6");
+    }
+}

--- a/cli/src/external_ip/resolver.rs
+++ b/cli/src/external_ip/resolver.rs
@@ -1,0 +1,78 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use rand::thread_rng;
+use rand::seq::SliceRandom;
+
+use super::providers::ProviderResolver;
+use super::providers::{icanhazip, identme, ipifyorg, ipinfoio, myip};
+
+
+
+
+/// Resolves the external IPv4 address randomly from a list of 5 service providers.
+/// Returns IP and the name of the service provider.
+pub async fn resolve_ipv4() -> Result<(Ipv4Addr, String), &'static str> {
+    let mut providers: Vec<ProviderResolver> = vec![];
+    providers.push(icanhazip::get_resolver());
+    providers.push(identme::get_resolver());
+    providers.push(ipifyorg::get_resolver());
+    providers.push(ipinfoio::get_resolver());
+    providers.push(myip::get_resolver());
+
+    let mut rng = thread_rng();
+    providers.shuffle(&mut rng);
+
+    for provider in providers {
+        match provider.ipv4().await {
+            Ok(ip) => return Ok((ip, provider.name.clone())),
+            Err(e) => {
+                println!("Failed to fetch ip from {}. {e}", provider.name);
+            },
+        }
+    }
+
+    Err("All ip providers failed to return the external ip.")
+}
+
+/// Resolves the external IPv6 address randomly from a list of 5 service providers.
+/// Returns IP and the name of the service provider.
+pub async fn resolve_ipv6() -> Result<(Ipv6Addr, String), &'static str> {
+    let mut providers: Vec<ProviderResolver> = vec![];
+    providers.push(icanhazip::get_resolver());
+    providers.push(identme::get_resolver());
+    providers.push(ipifyorg::get_resolver());
+    providers.push(ipinfoio::get_resolver());
+    providers.push(myip::get_resolver());
+
+    let mut rng = thread_rng();
+    providers.shuffle(&mut rng);
+
+    for provider in providers {
+        match provider.ipv6().await {
+            Ok(ip) => return Ok((ip, provider.name.clone())),
+            Err(e) => {
+                println!("Failed to fetch ip from {}. {e}", provider.name);
+            },
+        }
+    }
+
+    Err("All ip providers failed to return the external ip.")
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_ipv4() {
+        let ip = resolve_ipv4().await;
+        println!("{:?}", ip.expect("Valid ipv4"));
+    }
+
+    #[tokio::test]
+    async fn test_ipv6() {
+        let ip = resolve_ipv6().await;
+        println!("{:?}", ip.expect("Valid ipv6"));
+    }
+}

--- a/cli/src/external_ip/resolver.rs
+++ b/cli/src/external_ip/resolver.rs
@@ -1,12 +1,14 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Duration;
 
 use rand::thread_rng;
 use rand::seq::SliceRandom;
+use tokio::sync::{mpsc, Mutex};
 
 use super::providers::ProviderResolver;
 use super::providers::{icanhazip, identme, ipifyorg, ipinfoio, myip};
-
-
 
 
 /// Resolves the external IPv4 address randomly from a list of 5 service providers.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod helpers;
 mod pkarr_packet;
 mod simple_zone;
+mod external_ip;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/docs/dns-over-https.md
+++ b/docs/dns-over-https.md
@@ -26,3 +26,6 @@ pkdns supports [RFC8484](https://datatracker.ietf.org/doc/html/rfc8484) with the
 5. Test if everything is working with [http://7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy./](http://7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy./).
 
 
+## Enable DoH in Your Browser
+
+Most popular browser support DoH. See [here on how to enable your browser](https://support.privadovpn.com/kb/article/848-how-to-enable-doh-on-your-browser/).

--- a/docs/dyn-dns.md
+++ b/docs/dyn-dns.md
@@ -1,0 +1,18 @@
+# DynDNS
+
+DynDNS (Dynamic Domain Name System) is a service that allows users to assign a fixed domain name to a device with a dynamic IP address. This is particularly useful for home networks, servers, or remote devices that do not have a static IP from their Internet Service Provider (ISP).
+
+Key Purposes:
+- Remote Access – Enables access to home or office networks remotely using a consistent domain name.
+- Hosting Services – Supports hosting websites, game servers, or other services from a dynamic IP.
+- Simplified Configuration – Automatically updates DNS records when the IP address changes, avoiding manual reconfiguration.
+
+Essentially, DynDNS bridges the gap between dynamic IP addresses and the need for reliable remote access.
+
+## How does PKDNS Enable DynDNS?
+
+While publishing the `pkarr.zone` with `pkdns-cli`, the cli replaces the variables `{external_ipv4}` and `{external_ipv6}` with your actual external IP address. In combination with publishing your Public Key Domain (PKD)
+every 60 minutes, your PKD keeps pointing to the correct IP address.
+
+
+See [cli/sample/pkarr.zone](../cli/sample/pkarr.zone) as an example to use your external IPv4 address and [this guide](https://medium.com/pubky/how-to-host-a-public-key-domain-website-v0-6-0-ubuntu-24-04-57e6f2cb6f77) on how to publish it.


### PR DESCRIPTION
Adds support for two variables `{external_ipv4}` and `{external_ipv6}` to the pkarr.zone file. The two variables enable to use a PKD as DynDNS.

Background:

pkdns-cli uses the following services to determine the devices external IP address:
- icanhazip
- identme
- ipifyorg
- ipinfoio
- myip


If `{external_ipv4}` or `{external_ipv6}` is found in the pkarr.zone file, pkdns-cli will replace it with the resolved IP. In combination with the 60min crontab task to republish the zone, this acts as a DynDNS.

This partially resolves #25. Assuming a 60min republishing crontab task and a 5min TTL, a IP change will propagate within 65min. This is not perfect but a start. In the future, we should be able to optimize this down to 6min buyt this will require additional work.