### PR TITLE
feat: toml config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "dirs",
  "dnsoverhttps",
  "dyn-clone",
  "governor",
@@ -2575,6 +2576,7 @@ dependencies = [
  "simple-dns",
  "thiserror",
  "tokio 1.42.0",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2680,9 +2682,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3319,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa 1.0.11",
  "memchr",
@@ -3336,6 +3338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa 1.0.11",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -3666,18 +3677,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4025,6 +4036,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio 1.42.0",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4692,6 +4737,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,7 @@ members = [
   "cli"
 ]
 
+
+
 # See: https://github.com/rust-lang/rust/issues/90148#issuecomment-949194352
 resolver = "2"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,11 +26,12 @@ governor = "0.7.0"
 axum = { version = "0.7.9", features = ["tokio"]}
 axum-extra = { version = "0.9.6", features = ["typed-header"] }
 tower-http = { version = "0.6.2", features = ["cors"] }
-serde = "1.0.216"
+serde = {version = "1.0.216", features = ["derive"]}
 base64 = "0.22.1"
+toml = "0.8.19"
+dirs = "5.0.1"
+
 
 [dev-dependencies]
 axum-test = "16.4.1"
 dnsoverhttps = "0.6.0"
-
-

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,7 @@ ctrlc = "3.4.2"
 simple-dns = "0.6.0"
 pkarr = { version = "2.2.1", features = ["dht", "async", "rand"]}
 zbase32 = "0.1.2"
-clap = "4.4.18"
+clap = { version = "4.4.18", features = ["derive"] }
 chrono = "0.4.33"
 tokio = { version = "1.36.0", features = ["full"] }
 async-trait = "0.1.77"

--- a/server/pkdns.service
+++ b/server/pkdns.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 # Update the binary path. Add --verbose to the command if you want to have more insights.
-ExecStart=/usr/local/bin/pkdns --forward 8.8.8.8:53
+ExecStart=/usr/local/bin/pkdns
 Environment="RUST_BACKTRACE=full"
 Restart=on-failure
 RestartSec=5s

--- a/server/sample-config.toml
+++ b/server/sample-config.toml
@@ -1,0 +1,39 @@
+# PKDNS configuration file
+# More information on https://github.com/pubky/pkdns/server/sample-config.toml
+
+[general]
+# DNS UDP socket that pkdns is listening on.
+# socket = "0.0.0.0:53"
+
+# DNS server that pkdns is falling back to for regular ICANN queries.
+# forward = "8.8.8.8:53"
+
+# Verbose logging. See https://github.com/pubky/pkdns/blob/master/docs/logging.md
+# verbose = false
+
+# [EXPERIMENTAL] Enables DNS over HTTP on the given socket. Default: Disabled.
+# More info https://github.com/pubky/pkdns/blob/master/docs/dns-over-https.md
+# dns_over_http_socket = 127.0.0.1:3000
+
+[dns]
+# Minimum number of seconds a value is cached for before being refreshed.
+# min_ttl = 60
+
+# Maximum number of seconds before a cached value gets auto-refreshed. Set to 0 to prevent caching.
+# max_ttl = 86400
+
+# Maximum number of queries per second one IP address can make before it is rate limited. 0 is disabled.
+# query_rate_limit = 100
+
+# Short term burst size of the query-rate-limit. 0 is disabled.
+# query_rate_limit_burst = 200
+
+[dht]
+# Maximum size of the pkarr packet cache in megabytes.
+# cache_mb = 100
+
+# Maximum number of queries per second one IP address can make to the DHT before it is rate limited. 0 is disabled.
+# dht_query_rate_limit = 5
+
+# Short term burst size of the dht-rate-limit. 0 is disabled.
+# dht_query_rate_limit_burst = 25

--- a/server/sample-config.toml
+++ b/server/sample-config.toml
@@ -8,12 +8,11 @@
 # DNS server that pkdns is falling back to for regular ICANN queries.
 # forward = "8.8.8.8:53"
 
+# [EXPERIMENTAL] Enables DNS over HTTP on the given socket. Default: Disabled. More info https://github.com/pubky/pkdns/blob/master/docs/dns-over-https.md
+# dns_over_http_socket = 127.0.0.1:3000
+
 # Verbose logging. See https://github.com/pubky/pkdns/blob/master/docs/logging.md
 # verbose = false
-
-# [EXPERIMENTAL] Enables DNS over HTTP on the given socket. Default: Disabled.
-# More info https://github.com/pubky/pkdns/blob/master/docs/dns-over-https.md
-# dns_over_http_socket = 127.0.0.1:3000
 
 [dns]
 # Minimum number of seconds a value is cached for before being refreshed.

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -33,10 +33,10 @@ pub struct General {
     pub socket: SocketAddr,
     #[serde(default = "default_forward")]
     pub forward: SocketAddr,
-    #[serde(default = "default_false")]
-    pub verbose: bool,
     #[serde(default = "default_none")]
     pub dns_over_http_socket: Option<SocketAddr>,
+    #[serde(default = "default_false")]
+    pub verbose: bool,
 }
 
 impl Default for General {

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -1,0 +1,226 @@
+use anyhow::anyhow;
+use dirs::home_dir;
+
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    net::SocketAddr,
+    num::NonZeroU64,
+    path::{Path, PathBuf},
+};
+
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PkdnsConfig {
+    pub general: General,
+    pub dns: Dns,
+    pub dht: Dht,
+}
+
+impl Default for PkdnsConfig {
+    fn default() -> Self {
+        Self {
+            general: General::default(),
+            dns: Dns::default(),
+            dht: Dht::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct General {
+    #[serde(default = "default_socket")]
+    pub socket: SocketAddr,
+    #[serde(default = "default_forward")]
+    pub forward: SocketAddr,
+    #[serde(default = "default_false")]
+    pub verbose: bool,
+    #[serde(default = "default_none")]
+    pub dns_over_http_socket: Option<SocketAddr>,
+}
+
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            socket: default_socket(),
+            forward: default_forward(),
+            verbose: default_false(),
+            dns_over_http_socket: default_none(),
+        }
+    }
+}
+
+fn default_socket() -> SocketAddr {
+    "0.0.0.0:53".parse().unwrap()
+}
+
+fn default_forward() -> SocketAddr {
+    "8.8.8.8:53".parse().unwrap()
+}
+
+fn default_false() -> bool {
+    false
+}
+
+fn default_none() -> Option<SocketAddr> {
+    None
+}
+
+// fn default_true() -> bool {
+//     false
+// }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Dns {
+    #[serde(default = "default_min_ttl")]
+    pub min_ttl: u64,
+    #[serde(default = "default_max_ttl")]
+    pub max_ttl: u64,
+    #[serde(default = "default_query_rate_limit")]
+    pub query_rate_limit: u32,
+    #[serde(default = "default_query_rate_limit_burst")]
+    pub query_rate_limit_burst: u32,
+}
+
+impl Default for Dns {
+    fn default() -> Self {
+        Self {
+            min_ttl: default_min_ttl(),
+            max_ttl: default_max_ttl(),
+            query_rate_limit: default_query_rate_limit(),
+            query_rate_limit_burst: default_query_rate_limit_burst(),
+        }
+    }
+}
+
+fn default_min_ttl() -> u64 {
+    60
+}
+
+fn default_max_ttl() -> u64 {
+    86400
+}
+
+fn default_query_rate_limit() -> u32 {
+    100
+}
+
+fn default_query_rate_limit_burst() -> u32 {
+    200
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Dht {
+    #[serde(default = "default_cache_mb")]
+    pub cache_mb: NonZeroU64,
+    #[serde(default = "default_dht_rate_limit")]
+    pub dht_query_rate_limit: u32,
+    #[serde(default = "default_dht_rate_limit_burst")]
+    pub dht_query_rate_limit_burst: u32,
+}
+
+fn default_cache_mb() -> NonZeroU64 {
+    NonZeroU64::new(100).unwrap()
+}
+
+fn default_dht_rate_limit() -> u32 {
+    5
+}
+
+fn default_dht_rate_limit_burst() -> u32 {
+    25
+}
+
+impl Default for Dht {
+    fn default() -> Self {
+        Self {
+            cache_mb: default_cache_mb(),
+            dht_query_rate_limit: default_dht_rate_limit(),
+            dht_query_rate_limit_burst: default_dht_rate_limit_burst(),
+        }
+    }
+}
+
+/// Read the pkdns config file.
+pub fn read_config(path: &Path) -> Result<PkdnsConfig, anyhow::Error> {
+    let config_str = fs::read_to_string(path)?;
+    let config: PkdnsConfig = toml::from_str(&config_str)?;
+
+    Ok(config)
+}
+
+/// Read or create a config file at a given path.
+pub fn read_or_create_config(path: &str) -> Result<PkdnsConfig, anyhow::Error> {
+    let path = expand_tilde(path);
+    let config = read_config(path.as_path());
+    if config.is_ok() {
+        return config;
+    };
+
+    let err = config.unwrap_err();
+    tracing::debug!("Failed to read pkdns config file at {}. {err}", path.display());
+    tracing::info!("Create a new config file from scratch {}.", path.display());
+
+    let config = PkdnsConfig::default();
+    let full_config = toml::to_string(&config).expect("Valid toml config.");
+    let commented_out: Vec<String> = full_config.split("\n").map(|line| {
+        if line.contains("[") {
+            // Don't comment out sections.
+            line.to_string()
+        } else if line.is_empty() {
+            // Don't comment out empty lines.
+            line.to_string()
+        } else {
+            // Comment out regular lines
+            format!("# {line}")
+        }
+    }).collect();
+    let commented_out = commented_out.join("\n");
+
+    let content =
+        format!("# PKDNS configuration file\n# More information on https://github.com/pubky/pkdns/server/sample-config.toml\n\n{commented_out}");
+    fs::write(path, content).expect("Failed to write config file");
+    Ok(config)
+}
+
+/// Reads the config from the directory or if it doesn't exist, creates a new config in the directory.
+pub fn read_or_create_from_dir(dir_path: &str) -> Result<PkdnsConfig, anyhow::Error> {
+    let mut path = expand_tilde(dir_path);
+    if !path.exists() {
+        if let Err(e) = fs::create_dir(path.clone()) {
+            return Err(anyhow!(
+                "Failed to create pkdns_dir path {}. {e}",
+                path.display()
+            ));
+        };
+    };
+    if !path.is_dir() {
+        return Err(anyhow!("pkdns_dir {} is not a directory.", path.display()));
+    };
+    path.push("pkdns.toml");
+
+    read_or_create_config(path.to_str().expect("Valid path string"))
+}
+
+/// Expands the ~ to the users home directory
+pub fn expand_tilde(path: &str) -> PathBuf {
+    if path.starts_with("~") {
+        if let Some(home) = home_dir() {
+            let joined = home.join(&path[2..]);
+            return joined;
+        }
+    }
+    PathBuf::from(path)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[tokio::test]
+    async fn generate_sample_config() {
+        // println!("{}", PkdnsConfig::commented_toml());
+    }
+}

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -150,7 +150,7 @@ pub fn read_config(path: &Path) -> Result<PkdnsConfig, anyhow::Error> {
 }
 
 /// Read or create a config file at a given path.
-pub fn read_or_create_config(path: &str) -> Result<PkdnsConfig, anyhow::Error> {
+pub fn read_or_create_config(path: &PathBuf) -> Result<PkdnsConfig, anyhow::Error> {
     let path = expand_tilde(path);
     let config = read_config(path.as_path());
     if config.is_ok() {
@@ -184,7 +184,7 @@ pub fn read_or_create_config(path: &str) -> Result<PkdnsConfig, anyhow::Error> {
 }
 
 /// Reads the config from the directory or if it doesn't exist, creates a new config in the directory.
-pub fn read_or_create_from_dir(dir_path: &str) -> Result<PkdnsConfig, anyhow::Error> {
+pub fn read_or_create_from_dir(dir_path: &PathBuf) -> Result<PkdnsConfig, anyhow::Error> {
     let mut path = expand_tilde(dir_path);
     if !path.exists() {
         if let Err(e) = fs::create_dir(path.clone()) {
@@ -199,14 +199,15 @@ pub fn read_or_create_from_dir(dir_path: &str) -> Result<PkdnsConfig, anyhow::Er
     };
     path.push("pkdns.toml");
 
-    read_or_create_config(path.to_str().expect("Valid path string"))
+    read_or_create_config(&path)
 }
 
 /// Expands the ~ to the users home directory
-pub fn expand_tilde(path: &str) -> PathBuf {
-    if path.starts_with("~") {
+pub fn expand_tilde(path: &PathBuf) -> PathBuf {
+    if path.starts_with("~/") {
         if let Some(home) = home_dir() {
-            let joined = home.join(&path[2..]);
+            let without_home = path.strip_prefix("~/").expect("Invalid ~ prefix");
+            let joined = home.join(without_home);
             return joined;
         }
     }

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -1,0 +1,3 @@
+mod config_file;
+
+pub use config_file::{read_or_create_config, read_or_create_from_dir};

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -1,3 +1,3 @@
 mod config_file;
 
-pub use config_file::{read_or_create_config, read_or_create_from_dir};
+pub use config_file::{read_or_create_config, read_or_create_from_dir, PkdnsConfig};

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -1,3 +1,4 @@
 mod config_file;
 
-pub use config_file::{read_or_create_config, read_or_create_from_dir, PkdnsConfig};
+
+pub use config_file::{read_or_create_config, read_or_create_from_dir};

--- a/server/src/helpers.rs
+++ b/server/src/helpers.rs
@@ -65,3 +65,4 @@ pub(crate) async fn wait_on_ctrl_c() {
         }
     }
 }
+

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,16 +1,16 @@
+use config::{read_or_create_config, read_or_create_from_dir};
 use dns_over_https::run_doh_server;
 use helpers::{enable_logging, set_full_stacktrace_as_default, wait_on_ctrl_c};
 use resolution::DnsSocketBuilder;
 
-use std::{
-    error::Error,
-    net::{AddrParseError, SocketAddr},
-    num::NonZeroU32,
-};
+use std::error::Error;
 
 mod dns_over_https;
 mod helpers;
 mod resolution;
+mod config;
+
+
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -29,132 +29,53 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .help("ICANN fallback DNS server. IP:Port"),
         )
         .arg(
-            clap::Arg::new("socket")
-                .short('s')
-                .long("socket")
-                .required(false)
-                .default_value("0.0.0.0:53")
-                .help("Socket the server should listen on. IP:Port"),
-        )
-        .arg(
             clap::Arg::new("verbose")
                 .short('v')
                 .long("verbose")
                 .required(false)
                 .num_args(0)
                 .help("Show verbose output."),
-        )
-        .arg(
-            clap::Arg::new("min-ttl")
-                .long("min-ttl")
-                .required(false)
-                .default_value("60")
-                .help("Minimum number of seconds a value is cached for before being refreshed."),
-        )
-        .arg(
-            clap::Arg::new("max-ttl")
-                .long("max-ttl")
-                .required(false)
-                .default_value("86400") // 24hrs
-                .help("Maximum number of seconds before a cached value gets auto-refreshed."),
-        )
-        .arg(
-            clap::Arg::new("cache-mb")
-                .long("cache-mb")
-                .required(false)
-                .default_value("100")
-                .help("Maximum size of the pkarr packet cache in megabytes."),
         ).arg(
-            clap::Arg::new("query-rate-limit")
-                .long("query-rate-limit")
+            clap::Arg::new("pkdns-dir")
+                .short('d')
+                .long("pkdnsdir")
                 .required(false)
-                .default_value("0")
-                .help("Maximum number of queries per second one IP address can make before it is rate limited. 0 is disabled."),
+                .default_value("~/.pkdns")
+                .help("The base directory that contains pkdns's data, configuration file, etc."),
         ).arg(
-            clap::Arg::new("query-rate-limit-burst")
-                .long("query-rate-limit-burst")
+            clap::Arg::new("config")
+                .short('c')
+                .long("config")
                 .required(false)
-                .default_value("0")
-                .help("Short term burst size of the query-rate-limit. 0 is disabled."),
-        ).arg(
-            clap::Arg::new("dht-rate-limit")
-                .long("dht-rate-limit")
-                .required(false)
-                .default_value("5")
-                .help("Maximum number of queries per second one IP address can make to the DHT before it is rate limited. 0 is disabled."),
-        ).arg(
-            clap::Arg::new("dht-rate-limit-burst")
-                .long("dht-rate-limit-burst")
-                .required(false)
-                .default_value("25")
-                .help("Short term burst size of the dht-rate-limit. 0 is disabled."),
-        ).arg(
-            clap::Arg::new("doh")
-                .long("doh")
-                .required(false)
-                .help("[EXPERIMENTAL] Enables DNS over HTTP on the given socket. Example: 127.0.0.1:3000. Default: Disabled."),
+                .help("The path to pkdns configuration file. This will override the pkdnsdir config path."),
         );
 
     let matches = cmd.get_matches();
-    let verbose: bool = *matches.get_one("verbose").unwrap();
-    let max_ttl: &String = matches.get_one("max-ttl").unwrap();
-    let max_ttl: u64 = max_ttl
-        .parse()
-        .expect("max-ttl should be a valid valid positive integer.");
-    let min_ttl: &String = matches.get_one("min-ttl").unwrap();
-    let min_ttl: u64 = min_ttl
-        .parse()
-        .expect("min-ttl should be a valid valid positive integer.");
-    let cache_mb: &String = matches.get_one("cache-mb").unwrap();
-    let cache_mb: u64 = cache_mb
-        .parse()
-        .expect("cache-mb should be a valid valid positive integer of at least 1.");
+
+    let pkdns_dir: &String = matches.get_one("pkdns-dir").unwrap();
+    let config_path: Option<&String> = matches.get_one("config");
+    let mut config = match config_path {
+        Some(config_path) => {
+            read_or_create_config(config_path).expect("Failed to read valid config file")
+        },
+        None => {
+            read_or_create_from_dir(&pkdns_dir.as_str()).expect("Failed to read valid config file")
+        },
+    };
+
+    config.general.verbose = *matches.get_one("verbose").unwrap();
     let forward: &String = matches.get_one("forward").unwrap();
-    let mut forward: String = forward.clone();
-    if !forward.contains(":") {
-        forward.push_str(":53"); // Add default port
-    };
-    let forward: SocketAddr = forward.parse().expect("forward should be valid IP:Port combination.");
-    let socket: &String = matches.get_one("socket").unwrap();
-    let socket: SocketAddr = socket.parse().expect("socket should be valid IP:Port combination.");
+    config.general.forward = forward.parse().expect("forward should be valid IP:Port combination.");
 
-    let query_rate_limit: &String = matches.get_one("query-rate-limit").unwrap();
-    let query_rate_limit: u32 = query_rate_limit.parse().expect("query-rate-limit must be a >=0.");
-    let query_rate_limit_burst: &String = matches.get_one("query-rate-limit-burst").unwrap();
-    let query_rate_limit_burst: u32 = query_rate_limit_burst
-        .parse()
-        .expect("query-rate-limit-burst must be a >=0.");
-    let dht_rate_limit: &String = matches.get_one("dht-rate-limit").unwrap();
-    let dht_rate_limit: u32 = dht_rate_limit.parse().expect("dht-rate-limit must be a >=0.");
-    let dht_rate_limit_burst: &String = matches.get_one("dht-rate-limit-burst").unwrap();
-    let dht_rate_limit_burst: u32 = dht_rate_limit_burst
-        .parse()
-        .expect("dht-rate-limit-burst must be a >=0.");
 
-    let doh: Option<SocketAddr> = match matches.get_one("doh") {
-        Some(value) => {
-            let val: &String = value;
-            let socket: Result<SocketAddr, AddrParseError> = val.parse();
-            match socket {
-                Ok(s) => Some(s),
-                Err(e) => panic!("doh socket parse failed. {e} Expected ip:port combination."),
-            }
-        }
-        None => None,
-    };
+    enable_logging(config.general.verbose);
 
-    enable_logging(verbose);
-
-    if cache_mb <= 0 {
-        tracing::error!("--cache-mb must be at least 1. Given {cache_mb}.")
-    }
 
     tracing::info!("Starting pkdns v{VERSION}");
-    tracing::debug!("min_ttl={min_ttl} max_ttl={max_ttl} cache_mb={cache_mb} verbose={verbose} forward={forward} query_rate_limit={query_rate_limit} query_rate_limit_burst={query_rate_limit_burst} dht_rate_limit={dht_rate_limit} dht_rate_limit_burst={dht_rate_limit_burst} doh={doh:?}");
+    tracing::debug!("Configuration:\n{}", toml::to_string(&config).unwrap());
+    tracing::info!("Forward ICANN queries to {}", config.general.forward);
 
-    tracing::info!("Forward ICANN queries to {}", forward);
-
-    // Exit the main thread if a anydns thread panics. Todo: Add to anydns
+    // Exit the main thread if anything panics
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         // invoke the default handler and exit the process
@@ -163,40 +84,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::process::exit(1);
     }));
 
-    let dht_rate_limit_option = match dht_rate_limit {
-        0 => None,
-        val => Some(NonZeroU32::new(val).unwrap()),
-    };
-    let dht_rate_limit_burst_option = match dht_rate_limit_burst {
-        0 => None,
-        val => Some(NonZeroU32::new(val).unwrap()),
-    };
-    let query_rate_limit_option = match query_rate_limit {
-        0 => None,
-        val => Some(NonZeroU32::new(val).unwrap()),
-    };
-    let query_rate_limit_burst_option = match query_rate_limit_burst {
-        0 => None,
-        val => Some(NonZeroU32::new(val).unwrap()),
-    };
     let dns_socket = DnsSocketBuilder::new()
-        .listen(socket)
-        .icann_resolver(forward)
-        .cache_mb(cache_mb)
-        .min_ttl(min_ttl)
-        .max_ttl(max_ttl)
-        .max_dht_queries_per_ip_per_second(dht_rate_limit_option)
-        .max_dht_queries_per_ip_burst(dht_rate_limit_burst_option)
-        .max_queries_per_ip_per_second(query_rate_limit_option)
-        .max_queries_per_ip_burst(query_rate_limit_burst_option)
+        .listen(config.general.socket)
+        .icann_resolver(config.general.forward)
+        .cache_mb(config.dht.cache_mb)
+        .min_ttl(config.dns.min_ttl)
+        .max_ttl(config.dns.max_ttl)
+        .max_dht_queries_per_ip_per_second(config.dht.dht_query_rate_limit)
+        .max_dht_queries_per_ip_burst(config.dht.dht_query_rate_limit_burst)
+        .max_queries_per_ip_per_second(config.dns.query_rate_limit)
+        .max_queries_per_ip_burst(config.dns.query_rate_limit_burst)
         .build()
         .await?;
 
     let join_handle = dns_socket.start_receive_loop();
 
-    tracing::info!("Listening on {socket}. Waiting for Ctrl-C...");
+    tracing::info!("Listening on {}. Waiting for Ctrl-C...", config.general.socket);
 
-    if let Some(http_socket) = doh {
+    if let Some(http_socket) = config.general.dns_over_http_socket {
         run_doh_server(http_socket, dns_socket).await;
         tracing::info!("[EXPERIMENTAL] DNS-over-HTTP listening on http://{http_socket}/dns-query.");
     };

--- a/server/src/resolution/dns_socket.rs
+++ b/server/src/resolution/dns_socket.rs
@@ -8,7 +8,7 @@ use super::{
     rate_limiter::{RateLimiter, RateLimiterBuilder},
 };
 use simple_dns::{Packet, SimpleDnsError, RCODE};
-use std::hash::{Hash, Hasher};
+use std::{hash::{Hash, Hasher}, num::NonZeroU64};
 use std::num;
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -53,13 +53,13 @@ impl DnsSocket {
     pub async fn new(
         listening: SocketAddr,
         icann_resolver: SocketAddr,
-        max_queries_per_ip_per_second: Option<NonZeroU32>,
-        max_queries_per_ip_burst: Option<NonZeroU32>,
-        max_dht_queries_per_ip_per_second: Option<NonZeroU32>,
-        max_dht_queries_per_ip_burst: Option<NonZeroU32>,
+        max_queries_per_ip_per_second: u32,
+        max_queries_per_ip_burst: u32,
+        max_dht_queries_per_ip_per_second: u32,
+        max_dht_queries_per_ip_burst: u32,
         min_ttl: u64,
         max_ttl: u64,
-        cache_mb: u64,
+        cache_mb: NonZeroU64,
     ) -> tokio::io::Result<Self> {
         let socket = UdpSocket::bind(listening).await?;
         let limiter = RateLimiterBuilder::new()

--- a/server/src/resolution/dns_socket_builder.rs
+++ b/server/src/resolution/dns_socket_builder.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use std::{net::SocketAddr, num::NonZeroU32, sync::mpsc::channel};
+use std::{net::SocketAddr, num::{NonZeroI64, NonZeroU32, NonZeroU64}, sync::mpsc::channel};
 
 use super::dns_socket::DnsSocket;
 
@@ -11,11 +11,11 @@ pub struct DnsSocketBuilder {
     /// Listening address and port
     listen: SocketAddr,
 
-    /// Maximum number of dns queries one IP address can make per second.
-    max_queries_per_ip_per_second: Option<NonZeroU32>,
+    /// Maximum number of dns queries one IP address can make per second. 0 = disabled.
+    max_queries_per_ip_per_second: u32,
 
-    /// Burst size
-    max_queries_per_ip_burst_size: Option<NonZeroU32>,
+    /// Burst size. 0 = disabled.
+    max_queries_per_ip_burst_size: u32,
 
     /// Maximum number of seconds before a cached value gets auto-refreshed.
     max_ttl: u64,
@@ -24,13 +24,13 @@ pub struct DnsSocketBuilder {
     min_ttl: u64,
 
     /// Maximum size of the pkarr packet cache in megabytes.
-    cache_mb: u64,
+    cache_mb: NonZeroU64,
 
-    /// Maximum number of DHT queries one IP address can make per second.
-    max_dht_queries_per_ip_per_second: Option<NonZeroU32>,
+    /// Maximum number of DHT queries one IP address can make per second. 0 = disabled.
+    max_dht_queries_per_ip_per_second: u32,
 
-    /// Burst size of the rate limit.
-    max_dht_queries_per_ip_burst: Option<NonZeroU32>,
+    /// Burst size of the rate limit. 0 = disabled.
+    max_dht_queries_per_ip_burst: u32,
 }
 
 impl DnsSocketBuilder {
@@ -38,24 +38,24 @@ impl DnsSocketBuilder {
         Self {
             icann_resolver: SocketAddr::from(([8, 8, 8, 8], 53)),
             listen: SocketAddr::from(([0, 0, 0, 0], 53)),
-            max_queries_per_ip_per_second: None,
-            max_queries_per_ip_burst_size: None,
+            max_queries_per_ip_per_second: 0,
+            max_queries_per_ip_burst_size: 0,
             max_ttl: 60 * 60 * 24, // 1 day
             min_ttl: 60 * 1,
-            cache_mb: 100,
-            max_dht_queries_per_ip_per_second: None,
-            max_dht_queries_per_ip_burst: None,
+            cache_mb: NonZeroU64::new(100).unwrap(),
+            max_dht_queries_per_ip_per_second: 0,
+            max_dht_queries_per_ip_burst: 0,
         }
     }
 
     /// Rate limit the number of queries coming from a single IP address.
-    pub fn max_queries_per_ip_per_second(mut self, limit: Option<NonZeroU32>) -> Self {
+    pub fn max_queries_per_ip_per_second(mut self, limit: u32) -> Self {
         self.max_queries_per_ip_per_second = limit;
         self
     }
 
     /// Rate limit burst size
-    pub fn max_queries_per_ip_burst(mut self, burst_size: Option<NonZeroU32>) -> Self {
+    pub fn max_queries_per_ip_burst(mut self, burst_size: u32) -> Self {
         self.max_queries_per_ip_burst_size = burst_size;
         self
     }
@@ -85,19 +85,19 @@ impl DnsSocketBuilder {
     }
 
     /// pkarr cache size
-    pub fn cache_mb(mut self, megabytes: u64) -> Self {
+    pub fn cache_mb(mut self, megabytes: NonZeroU64) -> Self {
         self.cache_mb = megabytes;
         self
     }
 
     /// Rate the number of DHT queries by ip addresses.
-    pub fn max_dht_queries_per_ip_per_second(mut self, limit: Option<NonZeroU32>) -> Self {
+    pub fn max_dht_queries_per_ip_per_second(mut self, limit: u32) -> Self {
         self.max_dht_queries_per_ip_per_second = limit;
         self
     }
 
     /// Burst size of the rate limit.
-    pub fn max_dht_queries_per_ip_burst(mut self, burst: Option<NonZeroU32>) -> Self {
+    pub fn max_dht_queries_per_ip_burst(mut self, burst: u32) -> Self {
         self.max_dht_queries_per_ip_burst = burst;
         self
     }

--- a/server/src/resolution/pkd/pkarr_resolver.rs
+++ b/server/src/resolution/pkd/pkarr_resolver.rs
@@ -47,11 +47,11 @@ pub struct ResolverSettings {
     /// Used to resolve the bootstrap servers
     forward_dns_server: SocketAddr,
 
-    /// Maximum number of DHT queries one IP address can make per second.
-    max_dht_queries_per_ip_per_second: Option<NonZeroU32>,
+    /// Maximum number of DHT queries one IP address can make per second. 0 = disabled.
+    max_dht_queries_per_ip_per_second: u32,
 
-    /// Burst size of the rate limit.
-    max_dht_queries_per_ip_burst: Option<NonZeroU32>,
+    /// Burst size of the rate limit. 0 = disabled
+    max_dht_queries_per_ip_burst: u32,
 }
 
 impl ResolverSettings {
@@ -63,8 +63,8 @@ impl ResolverSettings {
             forward_dns_server: "8.8.8.8:53"
                 .parse()
                 .expect("forward should be valid IP:Port combination."),
-            max_dht_queries_per_ip_per_second: None,
-            max_dht_queries_per_ip_burst: None,
+            max_dht_queries_per_ip_per_second: 0,
+            max_dht_queries_per_ip_burst: 0,
         }
     }
 }
@@ -109,14 +109,14 @@ impl PkarrResolverBuilder {
         self
     }
 
-    /// Rate the number of DHT queries by ip addresses.
-    pub fn max_dht_queries_per_ip_per_second(mut self, limit: Option<NonZeroU32>) -> Self {
+    /// Rate the number of DHT queries by ip addresses. 0 = disabled.
+    pub fn max_dht_queries_per_ip_per_second(mut self, limit: u32) -> Self {
         self.settings.max_dht_queries_per_ip_per_second = limit;
         self
     }
 
-    /// Burst size of the rate limit.
-    pub fn max_dht_queries_per_ip_burst(mut self, burst: Option<NonZeroU32>) -> Self {
+    /// Burst size of the rate limit. 0 = disabled.
+    pub fn max_dht_queries_per_ip_burst(mut self, burst: u32) -> Self {
         self.settings.max_dht_queries_per_ip_burst = burst;
         self
     }


### PR DESCRIPTION
- Adds support for a toml config file called `pkdns.toml`.
- Uses the same pattern as in lnd or cln. Uses the `~/.pkdns` folder by default to save data and its config file.
- The `.pkdns` folder will be used for saving the cache to disk in the future.
- Reduce the number of cmd line args to a minimum to minimize the config effort. Might add more again later. This is a BREAKING CHANGE.
- Refactored cli args in general.
- Added sample config file.