### PR TITLE
feat: Add option to disable ANY type queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,7 @@ dependencies = [
  "dyn-clone",
  "governor",
  "moka",
+ "once_cell",
  "pkarr",
  "rustdns",
  "serde",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ serde = {version = "1.0.216", features = ["derive"]}
 base64 = "0.22.1"
 toml = "0.8.19"
 dirs = "5.0.1"
+once_cell = "1.20.2"
 
 
 [dev-dependencies]

--- a/server/sample-config.toml
+++ b/server/sample-config.toml
@@ -27,6 +27,9 @@
 # Short term burst size of the query-rate-limit. 0 is disabled.
 # query_rate_limit_burst = 200
 
+# Disables ANY queries by silently dropping them. This is used to protect against DNS amplification attacks.
+# disable_any_queries = false
+
 [dht]
 # Maximum size of the pkarr packet cache in megabytes.
 # cache_mb = 100

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PkdnsConfig {
     pub general: General,
     pub dns: Dns,
@@ -27,7 +27,7 @@ impl Default for PkdnsConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct General {
     #[serde(default = "default_socket")]
     pub socket: SocketAddr,
@@ -70,7 +70,7 @@ fn default_none() -> Option<SocketAddr> {
 //     false
 // }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Dns {
     #[serde(default = "default_min_ttl")]
     pub min_ttl: u64,
@@ -80,6 +80,8 @@ pub struct Dns {
     pub query_rate_limit: u32,
     #[serde(default = "default_query_rate_limit_burst")]
     pub query_rate_limit_burst: u32,
+    #[serde(default = "default_false")]
+    pub disable_any_queries: bool,
 }
 
 impl Default for Dns {
@@ -89,6 +91,7 @@ impl Default for Dns {
             max_ttl: default_max_ttl(),
             query_rate_limit: default_query_rate_limit(),
             query_rate_limit_burst: default_query_rate_limit_burst(),
+            disable_any_queries: default_false()
         }
     }
 }
@@ -109,7 +112,7 @@ fn default_query_rate_limit_burst() -> u32 {
     200
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Dht {
     #[serde(default = "default_cache_mb")]
     pub cache_mb: NonZeroU64,

--- a/server/src/config/global.rs
+++ b/server/src/config/global.rs
@@ -1,0 +1,20 @@
+use once_cell::sync::Lazy;
+use std::sync::RwLock;
+use super::config_file::PkdnsConfig;
+
+/// Safe the application wide configuration in a globally accessible way
+/// so we don't need to pass variables all over.
+
+pub static GLOBAL_CONFIG: Lazy<RwLock<PkdnsConfig>> = Lazy::new(|| RwLock::new(PkdnsConfig::default()));
+
+/// Updates the global configuration safely.
+pub fn update_global_config(new_value: PkdnsConfig) {
+    let mut config = GLOBAL_CONFIG.write().unwrap();
+    *config = new_value;
+}
+
+/// Returns a copy of the global configuration.
+pub fn get_global_config() -> PkdnsConfig {
+    let config = GLOBAL_CONFIG.read().unwrap();
+    config.clone()
+}

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod config_file;
-
+mod global;
 
 pub use config_file::{read_or_create_config, read_or_create_from_dir};
+pub use global::{update_global_config, get_global_config};

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use config::{read_or_create_config, read_or_create_from_dir};
+use config::{read_or_create_config, read_or_create_from_dir, update_global_config};
 use dns_over_https::run_doh_server;
 use helpers::{enable_logging, set_full_stacktrace_as_default, wait_on_ctrl_c};
 use resolution::DnsSocketBuilder;
@@ -52,6 +52,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if let Some(value) = cli.verbose {
         config.general.verbose = value;
     };
+
+    update_global_config(config.clone());
+
 
     enable_logging(config.general.verbose);
     const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Adds a config to disable `ANY` type queries. This is to prevent DNS Amplification attacks.
By default `disable_any_queries` is false.

Also, refactored the configuration. It is now available globally. This improves the readability of the code.