### PR TITLE
feat: ICANN response cache

### DIFF
--- a/server/sample-config.toml
+++ b/server/sample-config.toml
@@ -30,9 +30,12 @@
 # Disables ANY queries by silently dropping them. This is used to protect against DNS amplification attacks.
 # disable_any_queries = false
 
+# ICANN response cache size in megabytes.
+# icann_cache_mb = 100
+
 [dht]
 # Maximum size of the pkarr packet cache in megabytes.
-# cache_mb = 100
+# dht_cache_mb = 100
 
 # Maximum number of queries per second one IP address can make to the DHT before it is rate limited. 0 is disabled.
 # dht_query_rate_limit = 5

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -74,14 +74,21 @@ fn default_none() -> Option<SocketAddr> {
 pub struct Dns {
     #[serde(default = "default_min_ttl")]
     pub min_ttl: u64,
+
     #[serde(default = "default_max_ttl")]
     pub max_ttl: u64,
+
     #[serde(default = "default_query_rate_limit")]
     pub query_rate_limit: u32,
+
     #[serde(default = "default_query_rate_limit_burst")]
     pub query_rate_limit_burst: u32,
+
     #[serde(default = "default_false")]
     pub disable_any_queries: bool,
+
+    #[serde(default = "default_icann_cache_mb")]
+    pub icann_cache_mb: NonZeroU64,
 }
 
 impl Default for Dns {
@@ -91,7 +98,8 @@ impl Default for Dns {
             max_ttl: default_max_ttl(),
             query_rate_limit: default_query_rate_limit(),
             query_rate_limit_burst: default_query_rate_limit_burst(),
-            disable_any_queries: default_false()
+            disable_any_queries: default_false(),
+            icann_cache_mb: default_icann_cache_mb()
         }
     }
 }
@@ -112,10 +120,14 @@ fn default_query_rate_limit_burst() -> u32 {
     200
 }
 
+fn default_icann_cache_mb() -> NonZeroU64 {
+    NonZeroU64::new(100).unwrap()
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Dht {
     #[serde(default = "default_cache_mb")]
-    pub cache_mb: NonZeroU64,
+    pub dht_cache_mb: NonZeroU64,
     #[serde(default = "default_dht_rate_limit")]
     pub dht_query_rate_limit: u32,
     #[serde(default = "default_dht_rate_limit_burst")]
@@ -137,7 +149,7 @@ fn default_dht_rate_limit_burst() -> u32 {
 impl Default for Dht {
     fn default() -> Self {
         Self {
-            cache_mb: default_cache_mb(),
+            dht_cache_mb: default_cache_mb(),
             dht_query_rate_limit: default_dht_rate_limit(),
             dht_query_rate_limit_burst: default_dht_rate_limit_burst(),
         }
@@ -217,14 +229,3 @@ pub fn expand_tilde(path: &PathBuf) -> PathBuf {
     PathBuf::from(path)
 }
 
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-
-    #[tokio::test]
-    async fn generate_sample_config() {
-        // println!("{}", PkdnsConfig::commented_toml());
-    }
-}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let dns_socket = DnsSocketBuilder::new()
         .listen(config.general.socket)
         .icann_resolver(config.general.forward)
-        .cache_mb(config.dht.cache_mb)
+        .pkarr_cache_mb(config.dht.dht_cache_mb)
         .min_ttl(config.dns.min_ttl)
         .max_ttl(config.dns.max_ttl)
         .max_dht_queries_per_ip_per_second(config.dht.dht_query_rate_limit)

--- a/server/src/resolution/dns_socket_builder.rs
+++ b/server/src/resolution/dns_socket_builder.rs
@@ -1,6 +1,10 @@
 #![allow(unused)]
 
-use std::{net::SocketAddr, num::{NonZeroI64, NonZeroU32, NonZeroU64}, sync::mpsc::channel};
+use std::{
+    net::SocketAddr,
+    num::{NonZeroI64, NonZeroU32, NonZeroU64},
+    sync::mpsc::channel,
+};
 
 use super::dns_socket::DnsSocket;
 
@@ -24,7 +28,10 @@ pub struct DnsSocketBuilder {
     min_ttl: u64,
 
     /// Maximum size of the pkarr packet cache in megabytes.
-    cache_mb: NonZeroU64,
+    pkarr_cache_mb: NonZeroU64,
+
+    /// Maximum size of the icann response cache in megabytes.
+    icann_cache_mb: NonZeroU64,
 
     /// Maximum number of DHT queries one IP address can make per second. 0 = disabled.
     max_dht_queries_per_ip_per_second: u32,
@@ -42,9 +49,10 @@ impl DnsSocketBuilder {
             max_queries_per_ip_burst_size: 0,
             max_ttl: 60 * 60 * 24, // 1 day
             min_ttl: 60 * 1,
-            cache_mb: NonZeroU64::new(100).unwrap(),
+            pkarr_cache_mb: NonZeroU64::new(100).unwrap(),
             max_dht_queries_per_ip_per_second: 0,
             max_dht_queries_per_ip_burst: 0,
+            icann_cache_mb: NonZeroU64::new(100).unwrap(),
         }
     }
 
@@ -85,8 +93,14 @@ impl DnsSocketBuilder {
     }
 
     /// pkarr cache size
-    pub fn cache_mb(mut self, megabytes: NonZeroU64) -> Self {
-        self.cache_mb = megabytes;
+    pub fn pkarr_cache_mb(mut self, megabytes: NonZeroU64) -> Self {
+        self.pkarr_cache_mb = megabytes;
+        self
+    }
+
+    /// icann cache size
+    pub fn icann_cache_mb(mut self, megabytes: NonZeroU64) -> Self {
+        self.icann_cache_mb = megabytes;
         self
     }
 
@@ -113,7 +127,8 @@ impl DnsSocketBuilder {
             self.max_dht_queries_per_ip_burst,
             self.min_ttl,
             self.max_ttl,
-            self.cache_mb,
+            self.pkarr_cache_mb,
+            self.icann_cache_mb,
         )
         .await
     }

--- a/server/src/resolution/helpers.rs
+++ b/server/src/resolution/helpers.rs
@@ -1,0 +1,12 @@
+use simple_dns::{Packet, SimpleDnsError};
+
+/// Replaces the id of a dns packet.
+pub fn replace_packet_id(packet: &Vec<u8>, new_id: u16) -> Result<Vec<u8>, SimpleDnsError> {
+    let mut cloned = packet.clone();
+    let id_bytes = new_id.to_be_bytes();
+    std::mem::replace(&mut cloned[0], id_bytes[0]);
+    std::mem::replace(&mut cloned[1], id_bytes[1]);
+
+    let parsed_packet = Packet::parse(&cloned)?;
+    Ok(parsed_packet.build_bytes_vec()?)
+}

--- a/server/src/resolution/mod.rs
+++ b/server/src/resolution/mod.rs
@@ -10,7 +10,10 @@ mod pending_request;
 mod pkd;
 mod query_id_manager;
 mod rate_limiter;
+mod response_cache;
+mod helpers;
 
 pub use dns_socket::{DnsSocket, DnsSocketError};
 pub use dns_socket_builder::DnsSocketBuilder;
 pub use rate_limiter::{RateLimiter, RateLimiterBuilder};
+

--- a/server/src/resolution/response_cache.rs
+++ b/server/src/resolution/response_cache.rs
@@ -1,0 +1,167 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::anyhow;
+use moka::{future::Cache, policy::EvictionPolicy};
+use simple_dns::Packet;
+
+use crate::config::get_global_config;
+
+
+
+/// Caches dns responses.
+#[derive(Clone, Debug)]
+pub struct CacheItem {
+    pub query_key: String,
+    pub response: Vec<u8>,
+    created_at: SystemTime
+}
+
+impl CacheItem {
+    pub fn new(query: Vec<u8>, response: Vec<u8>) -> Result<Self, anyhow::Error> {
+        let _ = Packet::parse(&response)?; // Validate that the response is parseable.
+        Ok(Self {
+            query_key: Self::derive_query_key(&query)?,
+            response,
+            created_at: SystemTime::now(),
+        })
+    }
+
+    /// Derives a query key from the first question. May fail if the packet cant be parsed 
+    /// or the query doesn't have a question.
+    pub fn derive_query_key(query: &Vec<u8>) -> Result<String, anyhow::Error> {
+        let packet = Packet::parse(query)?;
+        let question = packet.questions.first().ok_or(anyhow!("Query does not include a question."))?;
+        Ok(format!("{}:{:?}:{:?}", question.qname, question.qclass, question.qtype))
+    }
+
+    fn response_packet(&self) -> Packet {
+        Packet::parse(&self.response).unwrap()
+    }
+
+
+    /// Lowest ttl of any anwser in seconds. Used to determine when to update the cache.
+    /// NotFound or packet with now answeres => None.
+    pub fn lowest_answer_ttl(&self) -> Option<u64> {
+        self.response_packet().answers.iter().map(|answer| answer.ttl as u64).min()
+    }
+
+
+    /// Size of the cached value in the memory.
+    /// Approximation. Could be done better.
+    pub fn memory_size(&self) -> usize {
+        self.query_key.len() + self.response.len() + 11
+    }
+
+    /// When this cached item expires.
+    pub fn expires_in(&self, min_ttl: u64, max_ttl: u64) -> SystemTime {
+        let ttl = self.lowest_answer_ttl().unwrap_or(min_ttl);
+        let ttl = if ttl < min_ttl { min_ttl } else { ttl };
+        let ttl = if ttl > max_ttl { max_ttl } else { ttl };
+        self.created_at.checked_add(Duration::from_secs(ttl)).expect("Valid time because ttl is bound")
+    }
+
+    /// If this cached item is outdated (expired ttl).
+    pub fn is_outdated(&self, min_ttl: u64, max_ttl: u64) -> bool {
+        return self.expires_in(min_ttl, max_ttl) < SystemTime::now()
+    }
+}
+
+/**
+ * LRU cache for ICANN responses.
+ */
+#[derive(Clone, Debug)]
+pub struct IcannLruCache {
+    cache: Cache<String, CacheItem>, // Moka Cache is thread safe
+    min_ttl: u64,
+    max_ttl: u64
+}
+
+impl IcannLruCache {
+    pub fn new(cache_size_mb: Option<u64>, min_ttl: u64, max_ttl: u64) -> Self {
+        let cache_size_mb = cache_size_mb.unwrap_or(100); // 100MB by default
+        IcannLruCache {
+            cache: Cache::builder()
+                .weigher(|_key, value: &CacheItem| -> u32 { value.memory_size() as u32 })
+                .max_capacity(cache_size_mb * 1024 * 1024)
+                .build(),
+                max_ttl,
+                min_ttl
+        }
+    }
+
+    /// Adds a new item to the cache.
+    pub async fn add(&mut self, query: Vec<u8>, response: Vec<u8>) -> Result<(), anyhow::Error> {
+        let item = CacheItem::new(query, response)?;
+        self.cache.insert(item.query_key.clone(), item).await;
+        Ok(())
+    }
+
+    /// Get cached packet by query. Fails if the query can't per parsed.
+    pub async fn get(&self, query: &Vec<u8>) -> Result<Option<CacheItem>, anyhow::Error> {
+        let key = CacheItem::derive_query_key(&query)?;
+        let value = self.cache.get(&key).await;
+        if let Some(item) = &value {
+            if item.is_outdated(self.min_ttl, self.max_ttl) {
+                return Ok(None)
+            };
+        };
+
+        Ok(value)
+    }
+
+    /// Approximated size of the cache in bytes. May not be 100% accurate due to pending counts.
+    #[allow(dead_code)]
+    pub fn approx_size_bytes(&self) -> u64 {
+        self.cache.weighted_size()
+    }
+
+    #[allow(dead_code)]
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use simple_dns::{rdata::A, Name, Question, ResourceRecord};
+    use super::*;
+
+    fn example_query_response(ttl: u32) -> (Vec<u8>, Vec<u8>) {
+        let mut query_packet = Packet::new_query(0);
+        let question = Question::new(
+            Name::new("example.com").unwrap(), simple_dns::QTYPE::ANY, simple_dns::QCLASS::ANY, false);
+        
+        query_packet.questions.push(question);
+        let query = query_packet.build_bytes_vec().unwrap();
+
+        let mut response_packet = Packet::new_reply(0);
+        let answer = ResourceRecord::new(Name::new("example.com").unwrap(), 
+        simple_dns::CLASS::IN, ttl, simple_dns::rdata::RData::A(A { address: 32 }));
+        response_packet.answers.push(answer);
+
+        let response = response_packet.build_bytes_vec().unwrap();
+        (query, response)
+    }
+
+    #[tokio::test]
+    async fn add_and_get() {
+        let mut cache = IcannLruCache::new(None, 0, 99999);
+        let (query, response ) = example_query_response(60);
+        cache.add(query.clone(), response.clone()).await.unwrap();
+        
+        let cache_option = cache.get(&query).await.expect("Previously cached item");
+        let res = cache_option.unwrap();
+        assert_eq!(res.response, response);
+    }
+
+    #[tokio::test]
+    async fn outdated_get() {
+        let mut cache = IcannLruCache::new(None, 0, 99999);
+        let (query, response ) = example_query_response(0);
+        cache.add(query.clone(), response.clone()).await.unwrap();
+        
+        let cache_option = cache.get(&query).await.expect("Previously cached item");
+        assert!(cache_option.is_none());
+    }
+
+}


### PR DESCRIPTION
Add support for the caching of ICANN responses.
New config variable: `icann_cache_mb`. Default: 100.

This should reduce the load on the forward server drastically.

Like with the pkarr cache, the icann cache can be controlled/disabled with the `min_ttl` and `max_ttl` settings.