### PR TITLE
feat: Optional Top Level Domain for Public Key Domains

### DIFF
--- a/server/sample-config.toml
+++ b/server/sample-config.toml
@@ -42,3 +42,6 @@
 
 # Short term burst size of the dht-rate-limit. 0 is disabled.
 # dht_query_rate_limit_burst = 25
+
+# Optional Top Level Domain for public key domains.
+# top_level_domain = "pkd"

--- a/server/sample-config.toml
+++ b/server/sample-config.toml
@@ -43,5 +43,5 @@
 # Short term burst size of the dht-rate-limit. 0 is disabled.
 # dht_query_rate_limit_burst = 25
 
-# Optional Top Level Domain for public key domains.
+# Optional Top Level Domain for public key domains. Set to "" to disable.
 # top_level_domain = "pkd"

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -135,6 +135,8 @@ pub struct Dht {
     pub dht_query_rate_limit: u32,
     #[serde(default = "default_dht_rate_limit_burst")]
     pub dht_query_rate_limit_burst: u32,
+    #[serde(default = "default_top_level_domain")]
+    pub top_level_domain: Option<String>,
 }
 
 fn default_cache_mb() -> NonZeroU64 {
@@ -149,12 +151,17 @@ fn default_dht_rate_limit_burst() -> u32 {
     25
 }
 
+fn default_top_level_domain() -> Option<String> {
+    Some("pkd".to_string())
+}
+
 impl Default for Dht {
     fn default() -> Self {
         Self {
             dht_cache_mb: default_cache_mb(),
             dht_query_rate_limit: default_dht_rate_limit(),
             dht_query_rate_limit_burst: default_dht_rate_limit_burst(),
+            top_level_domain: default_top_level_domain()
         }
     }
 }

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -1,7 +1,8 @@
 use anyhow::anyhow;
 use dirs::home_dir;
-
+use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
+use simple_dns::Name;
 use std::{
     fs,
     net::SocketAddr,
@@ -171,6 +172,17 @@ where
         },
         None => None,
     };
+
+    if let Some(label) = &value {
+        let parsed_name = Name::new(&label);
+        if let Err(e) = parsed_name {
+            return Err(e).map_err(D::Error::custom)
+        }
+        let name = parsed_name.unwrap();
+        if name.get_labels().len() != 1 {
+            return Err(anyhow!("TLD can only be one label")).map_err(D::Error::custom)
+        };
+    }
 
     Ok(value)
 }

--- a/server/src/config/config_file.rs
+++ b/server/src/config/config_file.rs
@@ -91,7 +91,7 @@ pub struct Dns {
     pub disable_any_queries: bool,
 
     #[serde(default = "default_icann_cache_mb")]
-    pub icann_cache_mb: NonZeroU64,
+    pub icann_cache_mb: u64,
 }
 
 impl Default for Dns {
@@ -123,8 +123,8 @@ fn default_query_rate_limit_burst() -> u32 {
     200
 }
 
-fn default_icann_cache_mb() -> NonZeroU64 {
-    NonZeroU64::new(100).unwrap()
+fn default_icann_cache_mb() -> u64 {
+    100
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/server/src/config/global.rs
+++ b/server/src/config/global.rs
@@ -1,6 +1,6 @@
+use super::config_file::PkdnsConfig;
 use once_cell::sync::Lazy;
 use std::sync::RwLock;
-use super::config_file::PkdnsConfig;
 
 /// Safe the application wide configuration in a globally accessible way
 /// so we don't need to pass variables all over.

--- a/server/src/config/mod.rs
+++ b/server/src/config/mod.rs
@@ -2,4 +2,4 @@ mod config_file;
 mod global;
 
 pub use config_file::{read_or_create_config, read_or_create_from_dir};
-pub use global::{update_global_config, get_global_config};
+pub use global::{get_global_config, update_global_config};

--- a/server/src/dns_over_https/server.rs
+++ b/server/src/dns_over_https/server.rs
@@ -9,7 +9,11 @@ use axum::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use simple_dns::Packet;
-use std::{collections::HashMap, net::{IpAddr, SocketAddr}, sync::Arc};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 use tower_http::cors::{Any, CorsLayer};
 
 /// RFC8484 Dns-over-http wireformat
@@ -84,7 +88,7 @@ fn extract_client_ip(request_addr: &SocketAddr, headers: &HeaderMap) -> IpAddr {
         Err(e) => {
             tracing::debug!("Failed to parse the 'x-forwarded-for' header ip address. {e}");
             request_addr.ip()
-        },
+        }
     }
 }
 
@@ -169,16 +173,15 @@ pub async fn run_doh_server(addr: SocketAddr, dns_socket: DnsSocket) {
     let app = create_app(dns_socket);
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     tokio::spawn(async move {
-        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await.unwrap();
+        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+            .unwrap();
     });
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        dns_over_https::server::create_app,
-        resolution::DnsSocket,
-    };
+    use crate::{dns_over_https::server::create_app, resolution::DnsSocket};
     use axum_test::TestServer;
     use simple_dns::{Name, Packet, Question};
 

--- a/server/src/helpers.rs
+++ b/server/src/helpers.rs
@@ -65,4 +65,3 @@ pub(crate) async fn wait_on_ctrl_c() {
         }
     }
 }
-

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -77,6 +77,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let dns_socket = DnsSocketBuilder::new()
         .listen(config.general.socket)
         .icann_resolver(config.general.forward)
+        .icann_cache_mb(config.dns.icann_cache_mb)
         .pkarr_cache_mb(config.dht.dht_cache_mb)
         .min_ttl(config.dns.min_ttl)
         .max_ttl(config.dns.max_ttl)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .max_dht_queries_per_ip_burst(config.dht.dht_query_rate_limit_burst)
         .max_queries_per_ip_per_second(config.dns.query_rate_limit)
         .max_queries_per_ip_burst(config.dns.query_rate_limit_burst)
+        .top_level_domain(config.dht.top_level_domain)
         .build()
         .await?;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -57,7 +57,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     update_global_config(config.clone());
 
-
     enable_logging(config.general.verbose);
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/server/src/resolution/dns_socket.rs
+++ b/server/src/resolution/dns_socket.rs
@@ -6,9 +6,7 @@ use crate::{
 
 use super::{
     pending_request::{PendingRequest, PendingRequestStore},
-    pkd::{PkarrResolver, ResolverSettings, TopLevelDomain, 
-        // PkarrResolverBuilder
-    },
+    pkd::{PkarrResolver, ResolverSettings, TopLevelDomain},
     query_id_manager::QueryIdManager,
     rate_limiter::{RateLimiter, RateLimiterBuilder},
     response_cache::IcannLruCache,
@@ -76,7 +74,7 @@ impl DnsSocket {
         max_ttl: u64,
         pkarr_cache_mb: NonZeroU64,
         icann_cache_mb: u64,
-        top_level_domain: Option<TopLevelDomain>
+        top_level_domain: Option<TopLevelDomain>,
     ) -> tokio::io::Result<Self> {
         let socket = UdpSocket::bind(listening).await?;
         let limiter = RateLimiterBuilder::new()

--- a/server/src/resolution/dns_socket.rs
+++ b/server/src/resolution/dns_socket.rs
@@ -6,7 +6,9 @@ use crate::{
 
 use super::{
     pending_request::{PendingRequest, PendingRequestStore},
-    pkd::PkarrResolver,
+    pkd::{PkarrResolver, 
+        // PkarrResolverBuilder
+    },
     query_id_manager::QueryIdManager,
     rate_limiter::{RateLimiter, RateLimiterBuilder},
     response_cache::IcannLruCache,
@@ -82,6 +84,8 @@ impl DnsSocket {
 
         let config = get_global_config();
 
+        // TODO: Respect all the user config
+        // PkarrResolverBuilder::new().cache_mb(pkarr_cache_mb.into()).;
         let resolver = PkarrResolver::default().await;
         Ok(Self {
             socket: Arc::new(socket),

--- a/server/src/resolution/dns_socket.rs
+++ b/server/src/resolution/dns_socket.rs
@@ -75,7 +75,7 @@ impl DnsSocket {
         min_ttl: u64,
         max_ttl: u64,
         pkarr_cache_mb: NonZeroU64,
-        icann_cache_mb: NonZeroU64,
+        icann_cache_mb: u64,
         top_level_domain: Option<TopLevelDomain>
     ) -> tokio::io::Result<Self> {
         let socket = UdpSocket::bind(listening).await?;
@@ -103,7 +103,7 @@ impl DnsSocket {
             id_manager: QueryIdManager::new(),
             rate_limiter: Arc::new(limiter.build()),
             disable_any_queries: config.dns.disable_any_queries,
-            icann_cache: IcannLruCache::new(Some(icann_cache_mb.into()), min_ttl, max_ttl),
+            icann_cache: IcannLruCache::new(icann_cache_mb, min_ttl, max_ttl),
         })
     }
 
@@ -375,7 +375,7 @@ impl DnsSocket {
             id_manager: QueryIdManager::new(),
             rate_limiter: Arc::new(RateLimiterBuilder::new().build()),
             disable_any_queries: config.dns.disable_any_queries,
-            icann_cache: IcannLruCache::new(None, config.dns.min_ttl, config.dns.max_ttl),
+            icann_cache: IcannLruCache::new(100, config.dns.min_ttl, config.dns.max_ttl),
         })
     }
 }

--- a/server/src/resolution/dns_socket_builder.rs
+++ b/server/src/resolution/dns_socket_builder.rs
@@ -6,7 +6,7 @@ use std::{
     sync::mpsc::channel,
 };
 
-use super::dns_socket::DnsSocket;
+use super::{dns_socket::DnsSocket, pkd::TopLevelDomain};
 
 pub struct DnsSocketBuilder {
     /// Forward DNS resolver
@@ -38,6 +38,8 @@ pub struct DnsSocketBuilder {
 
     /// Burst size of the rate limit. 0 = disabled.
     max_dht_queries_per_ip_burst: u32,
+
+    top_level_domain: Option<TopLevelDomain>,
 }
 
 impl DnsSocketBuilder {
@@ -53,6 +55,7 @@ impl DnsSocketBuilder {
             max_dht_queries_per_ip_per_second: 0,
             max_dht_queries_per_ip_burst: 0,
             icann_cache_mb: NonZeroU64::new(100).unwrap(),
+            top_level_domain: None,
         }
     }
 
@@ -113,6 +116,12 @@ impl DnsSocketBuilder {
     /// Burst size of the rate limit.
     pub fn max_dht_queries_per_ip_burst(mut self, burst: u32) -> Self {
         self.max_dht_queries_per_ip_burst = burst;
+        self
+    }
+
+    /// Burst size of the rate limit.
+    pub fn top_level_domain(mut self, label: String) -> Self {
+        self.top_level_domain = Some(TopLevelDomain(label));
         self
     }
 

--- a/server/src/resolution/dns_socket_builder.rs
+++ b/server/src/resolution/dns_socket_builder.rs
@@ -120,8 +120,11 @@ impl DnsSocketBuilder {
     }
 
     /// Burst size of the rate limit.
-    pub fn top_level_domain(mut self, label: String) -> Self {
-        self.top_level_domain = Some(TopLevelDomain(label));
+    pub fn top_level_domain(mut self, label: Option<String>) -> Self {
+        match label {
+            Some(val) => self.top_level_domain = Some(TopLevelDomain(val)),
+            None => self.top_level_domain = None,
+        };
         self
     }
 
@@ -138,6 +141,7 @@ impl DnsSocketBuilder {
             self.max_ttl,
             self.pkarr_cache_mb,
             self.icann_cache_mb,
+            self.top_level_domain
         )
         .await
     }

--- a/server/src/resolution/dns_socket_builder.rs
+++ b/server/src/resolution/dns_socket_builder.rs
@@ -31,7 +31,7 @@ pub struct DnsSocketBuilder {
     pkarr_cache_mb: NonZeroU64,
 
     /// Maximum size of the icann response cache in megabytes.
-    icann_cache_mb: NonZeroU64,
+    icann_cache_mb: u64,
 
     /// Maximum number of DHT queries one IP address can make per second. 0 = disabled.
     max_dht_queries_per_ip_per_second: u32,
@@ -54,7 +54,7 @@ impl DnsSocketBuilder {
             pkarr_cache_mb: NonZeroU64::new(100).unwrap(),
             max_dht_queries_per_ip_per_second: 0,
             max_dht_queries_per_ip_burst: 0,
-            icann_cache_mb: NonZeroU64::new(100).unwrap(),
+            icann_cache_mb: 100,
             top_level_domain: None,
         }
     }
@@ -102,7 +102,7 @@ impl DnsSocketBuilder {
     }
 
     /// icann cache size
-    pub fn icann_cache_mb(mut self, megabytes: NonZeroU64) -> Self {
+    pub fn icann_cache_mb(mut self, megabytes: u64) -> Self {
         self.icann_cache_mb = megabytes;
         self
     }

--- a/server/src/resolution/dns_socket_builder.rs
+++ b/server/src/resolution/dns_socket_builder.rs
@@ -141,7 +141,7 @@ impl DnsSocketBuilder {
             self.max_ttl,
             self.pkarr_cache_mb,
             self.icann_cache_mb,
-            self.top_level_domain
+            self.top_level_domain,
         )
         .await
     }

--- a/server/src/resolution/mod.rs
+++ b/server/src/resolution/mod.rs
@@ -6,14 +6,13 @@
  */
 mod dns_socket;
 mod dns_socket_builder;
+mod helpers;
 mod pending_request;
 mod pkd;
 mod query_id_manager;
 mod rate_limiter;
 mod response_cache;
-mod helpers;
 
 pub use dns_socket::{DnsSocket, DnsSocketError};
 pub use dns_socket_builder::DnsSocketBuilder;
 pub use rate_limiter::{RateLimiter, RateLimiterBuilder};
-

--- a/server/src/resolution/pkd/mod.rs
+++ b/server/src/resolution/pkd/mod.rs
@@ -6,5 +6,9 @@ mod query_matcher;
 mod top_level_domain;
 
 pub use pkarr_resolver::{
-    CustomHandlerError, PkarrResolver, PkarrResolverBuilder, PkarrResolverError, ResolverSettings,
+    CustomHandlerError, PkarrResolver, 
+    // PkarrResolverBuilder, 
+    PkarrResolverError, ResolverSettings,
 };
+
+pub use top_level_domain::TopLevelDomain;

--- a/server/src/resolution/pkd/mod.rs
+++ b/server/src/resolution/pkd/mod.rs
@@ -3,6 +3,7 @@ mod pkarr_cache;
 mod pkarr_resolver;
 mod pubkey_parser;
 mod query_matcher;
+mod top_level_domain;
 
 pub use pkarr_resolver::{
     CustomHandlerError, PkarrResolver, PkarrResolverBuilder, PkarrResolverError, ResolverSettings,

--- a/server/src/resolution/pkd/mod.rs
+++ b/server/src/resolution/pkd/mod.rs
@@ -5,10 +5,6 @@ mod pubkey_parser;
 mod query_matcher;
 mod top_level_domain;
 
-pub use pkarr_resolver::{
-    CustomHandlerError, PkarrResolver, 
-    // PkarrResolverBuilder, 
-    PkarrResolverError, ResolverSettings,
-};
+pub use pkarr_resolver::{CustomHandlerError, PkarrResolver, PkarrResolverError, ResolverSettings};
 
 pub use top_level_domain::TopLevelDomain;

--- a/server/src/resolution/pkd/pkarr_cache.rs
+++ b/server/src/resolution/pkd/pkarr_cache.rs
@@ -67,7 +67,7 @@ impl CacheItem {
         }
     }
 
-    pub fn is_not_found(&self) -> bool {
+    pub fn not_found(&self) -> bool {
         !self.is_found()
     }
 

--- a/server/src/resolution/pkd/pkarr_resolver.rs
+++ b/server/src/resolution/pkd/pkarr_resolver.rs
@@ -1,4 +1,6 @@
-use super::{pubkey_parser::parse_pkarr_uri, query_matcher::create_domain_not_found_reply, top_level_domain::TopLevelDomain};
+use super::{
+    pubkey_parser::parse_pkarr_uri, query_matcher::create_domain_not_found_reply, top_level_domain::TopLevelDomain,
+};
 use crate::resolution::{DnsSocket, DnsSocketError, RateLimiter, RateLimiterBuilder};
 use simple_dns::{Name, Question, ResourceRecord};
 use std::{
@@ -83,54 +85,6 @@ pub enum PkarrResolverError {
     DnsSocket(#[from] DnsSocketError),
 }
 
-// pub struct PkarrResolverBuilder {
-//     settings: ResolverSettings,
-// }
-
-// impl PkarrResolverBuilder {
-//     pub fn new() -> Self {
-//         Self {
-//             settings: ResolverSettings::default(),
-//         }
-//     }
-
-//     pub fn forward_server(mut self, socket: SocketAddr) -> Self {
-//         self.settings.forward_dns_server = socket;
-//         self
-//     }
-
-//     pub fn max_ttl(mut self, rate_s: u64) -> Self {
-//         self.settings.max_ttl = rate_s;
-//         self
-//     }
-
-//     pub fn min_ttl(mut self, rate_s: u64) -> Self {
-//         self.settings.min_ttl = rate_s;
-//         self
-//     }
-
-//     pub fn cache_mb(mut self, megabytes: u64) -> Self {
-//         self.settings.cache_mb = megabytes;
-//         self
-//     }
-
-//     /// Rate the number of DHT queries by ip addresses. 0 = disabled.
-//     pub fn max_dht_queries_per_ip_per_second(mut self, limit: u32) -> Self {
-//         self.settings.max_dht_queries_per_ip_per_second = limit;
-//         self
-//     }
-
-//     /// Burst size of the rate limit. 0 = disabled.
-//     pub fn max_dht_queries_per_ip_burst(mut self, burst: u32) -> Self {
-//         self.settings.max_dht_queries_per_ip_burst = burst;
-//         self
-//     }
-
-//     pub fn build_settings(self) -> ResolverSettings {
-//         self.settings
-//     }
-// }
-
 /**
  * Pkarr resolver with cache.
  */
@@ -170,10 +124,6 @@ impl PkarrResolver {
     pub async fn default() -> Self {
         Self::new(ResolverSettings::default()).await
     }
-
-    // pub fn builder() -> PkarrResolverBuilder {
-    //     PkarrResolverBuilder::new()
-    // }
 
     pub async fn new(settings: ResolverSettings) -> Self {
         let addrs = Self::resolve_bootstrap_nodes(&settings.forward_dns_server);
@@ -262,7 +212,6 @@ impl PkarrResolver {
         Ok(self.cache.add_packet(new_packet).await)
     }
 
-
     fn remove_tld_if_necessary(&self, mut query: &mut Packet<'_>) -> bool {
         if let Some(tld) = &self.settings.top_level_domain {
             if tld.question_ends_with_pubkey_tld(&query) {
@@ -270,7 +219,7 @@ impl PkarrResolver {
                 return true;
             }
         }
-        return false
+        return false;
     }
 
     fn add_tld_if_necessary(&self, mut reply: &mut Packet<'_>) -> bool {
@@ -278,7 +227,7 @@ impl PkarrResolver {
             tld.add(reply);
             return true;
         }
-        return false
+        return false;
     }
 
     /**
@@ -299,7 +248,8 @@ impl PkarrResolver {
         let question = request
             .questions
             .first()
-            .expect("No question in query in pkarr_resolver.").clone();
+            .expect("No question in query in pkarr_resolver.")
+            .clone();
         let labels = question.qname.get_labels();
         let mut public_key = labels
             .last()
@@ -344,7 +294,6 @@ impl PkarrResolver {
             Err(err) => Err(err),
         }
     }
-
 }
 
 #[cfg(test)]

--- a/server/src/resolution/pkd/pkarr_resolver.rs
+++ b/server/src/resolution/pkd/pkarr_resolver.rs
@@ -1,5 +1,6 @@
-use super::{pubkey_parser::parse_pkarr_uri, query_matcher::create_domain_not_found_reply};
+use super::{pubkey_parser::parse_pkarr_uri, query_matcher::create_domain_not_found_reply, top_level_domain::TopLevelDomain};
 use crate::resolution::{DnsSocket, DnsSocketError, RateLimiter, RateLimiterBuilder};
+use simple_dns::{Name, Question, ResourceRecord};
 use std::{
     collections::HashMap,
     net::{IpAddr, SocketAddr},
@@ -52,6 +53,9 @@ pub struct ResolverSettings {
 
     /// Burst size of the rate limit. 0 = disabled
     max_dht_queries_per_ip_burst: u32,
+
+    /// Top level domain like `.pkd`.
+    top_level_domain: Option<TopLevelDomain>,
 }
 
 impl ResolverSettings {
@@ -65,6 +69,7 @@ impl ResolverSettings {
                 .expect("forward should be valid IP:Port combination."),
             max_dht_queries_per_ip_per_second: 0,
             max_dht_queries_per_ip_burst: 0,
+            top_level_domain: Some(TopLevelDomain("pkd".to_string())),
         }
     }
 }
@@ -257,6 +262,25 @@ impl PkarrResolver {
         Ok(self.cache.add_packet(new_packet).await)
     }
 
+
+    fn remove_tld_if_necessary(&self, mut query: &mut Packet<'_>) -> bool {
+        if let Some(tld) = &self.settings.top_level_domain {
+            if tld.question_ends_with_pubkey_tld(&query) {
+                tld.remove(query);
+                return true;
+            }
+        }
+        return false
+    }
+
+    fn add_tld_if_necessary(&self, mut reply: &mut Packet<'_>) -> bool {
+        if let Some(tld) = &self.settings.top_level_domain {
+            tld.add(reply);
+            return true;
+        }
+        return false
+    }
+
     /**
      * Resolves a domain with pkarr.
      */
@@ -266,33 +290,31 @@ impl PkarrResolver {
         from: Option<IpAddr>,
     ) -> std::prelude::v1::Result<Vec<u8>, CustomHandlerError> {
         // anydns validated the query before.
-        let request = Packet::parse(query).expect("Unparsable query in pkarr_resolver.");
+        let mut request = Packet::parse(&query).expect("Unparsable query in pkarr_resolver.");
+        let mut removed_tld = self.remove_tld_if_necessary(&mut request);
+        if removed_tld {
+            tracing::trace!("Removed tld from question: {:?}", request.questions.first().unwrap());
+        }
+
         let question = request
             .questions
             .first()
-            .expect("No question in query in pkarr_resolver.");
+            .expect("No question in query in pkarr_resolver.").clone();
         let labels = question.qname.get_labels();
-
-        tracing::debug!(
-            "New query: {} {:?} id={}",
-            question.qname.to_string(),
-            question.qtype,
-            request.id()
-        );
-
-        let tld = labels
+        let mut public_key = labels
             .last()
             .expect("Question labels with no domain in pkarr_resolver")
             .to_string();
-        let parsed_option = parse_pkarr_uri(&tld);
+
+        let parsed_option = parse_pkarr_uri(&public_key);
         if let Err(e) = parsed_option {
             return match e {
                 super::pubkey_parser::PubkeyParserError::InvalidKey(_) => {
-                    tracing::trace!("TLD .{tld} is not a pkarr key. Fallback to ICANN.");
+                    tracing::trace!("TLD .{public_key} is not a pkarr key. Fallback to ICANN.");
                     Err(CustomHandlerError::Unhandled)
                 }
                 super::pubkey_parser::PubkeyParserError::ValidButDifferent => {
-                    tracing::trace!("TLD .{tld} is a pkarr key but its last bits are invalid.");
+                    tracing::trace!("TLD .{public_key} is a pkarr key but its last bits are invalid.");
                     Ok(create_domain_not_found_reply(request.id()))
                 }
             };
@@ -303,17 +325,27 @@ impl PkarrResolver {
         match self.resolve_pubkey_respect_cache(&pubkey, from).await {
             Ok(item) => {
                 if item.is_not_found() {
-                    Ok(create_domain_not_found_reply(request.id()))
+                    return Ok(create_domain_not_found_reply(request.id()));
+                };
+
+                let signed_packet = item.unwrap();
+                let packet = signed_packet.packet();
+                let reply = resolve_query(packet, &request).await;
+
+                let reply = if removed_tld {
+                    let mut packet = Packet::parse(&reply).unwrap();
+                    self.add_tld_if_necessary(&mut packet);
+
+                    packet.build_bytes_vec().unwrap()
                 } else {
-                    let signed_packet = item.unwrap();
-                    let packet = signed_packet.packet();
-                    let reply = resolve_query(packet, &request).await;
-                    Ok(reply)
-                }
+                    reply
+                };
+                Ok(reply)
             }
             Err(err) => Err(err),
         }
     }
+
 }
 
 #[cfg(test)]

--- a/server/src/resolution/pkd/pkarr_resolver.rs
+++ b/server/src/resolution/pkd/pkarr_resolver.rs
@@ -36,26 +36,26 @@ pub enum CustomHandlerError {
 #[derive(Clone, Debug)]
 pub struct ResolverSettings {
     /// Maximum number of seconds before a cached value gets auto-refreshed.
-    max_ttl: u64,
+    pub max_ttl: u64,
 
     /// Minimum number of seconds a value is cached for before being refreshed.
-    min_ttl: u64,
+    pub min_ttl: u64,
 
     /// Maximum size of the pkarr packet cache in megabytes.
-    cache_mb: u64,
+    pub cache_mb: u64,
 
     /// IP:port combination of the dns server regular ICANN queries should be forwarded to.
     /// Used to resolve the bootstrap servers
-    forward_dns_server: SocketAddr,
+    pub forward_dns_server: SocketAddr,
 
     /// Maximum number of DHT queries one IP address can make per second. 0 = disabled.
-    max_dht_queries_per_ip_per_second: u32,
+    pub max_dht_queries_per_ip_per_second: u32,
 
     /// Burst size of the rate limit. 0 = disabled
-    max_dht_queries_per_ip_burst: u32,
+    pub max_dht_queries_per_ip_burst: u32,
 
     /// Top level domain like `.pkd`.
-    top_level_domain: Option<TopLevelDomain>,
+    pub top_level_domain: Option<TopLevelDomain>,
 }
 
 impl ResolverSettings {

--- a/server/src/resolution/pkd/pkarr_resolver.rs
+++ b/server/src/resolution/pkd/pkarr_resolver.rs
@@ -83,53 +83,53 @@ pub enum PkarrResolverError {
     DnsSocket(#[from] DnsSocketError),
 }
 
-pub struct PkarrResolverBuilder {
-    settings: ResolverSettings,
-}
+// pub struct PkarrResolverBuilder {
+//     settings: ResolverSettings,
+// }
 
-impl PkarrResolverBuilder {
-    pub fn new() -> Self {
-        Self {
-            settings: ResolverSettings::default(),
-        }
-    }
+// impl PkarrResolverBuilder {
+//     pub fn new() -> Self {
+//         Self {
+//             settings: ResolverSettings::default(),
+//         }
+//     }
 
-    pub fn forward_server(mut self, socket: SocketAddr) -> Self {
-        self.settings.forward_dns_server = socket;
-        self
-    }
+//     pub fn forward_server(mut self, socket: SocketAddr) -> Self {
+//         self.settings.forward_dns_server = socket;
+//         self
+//     }
 
-    pub fn max_ttl(mut self, rate_s: u64) -> Self {
-        self.settings.max_ttl = rate_s;
-        self
-    }
+//     pub fn max_ttl(mut self, rate_s: u64) -> Self {
+//         self.settings.max_ttl = rate_s;
+//         self
+//     }
 
-    pub fn min_ttl(mut self, rate_s: u64) -> Self {
-        self.settings.min_ttl = rate_s;
-        self
-    }
+//     pub fn min_ttl(mut self, rate_s: u64) -> Self {
+//         self.settings.min_ttl = rate_s;
+//         self
+//     }
 
-    pub fn cache_mb(mut self, megabytes: u64) -> Self {
-        self.settings.cache_mb = megabytes;
-        self
-    }
+//     pub fn cache_mb(mut self, megabytes: u64) -> Self {
+//         self.settings.cache_mb = megabytes;
+//         self
+//     }
 
-    /// Rate the number of DHT queries by ip addresses. 0 = disabled.
-    pub fn max_dht_queries_per_ip_per_second(mut self, limit: u32) -> Self {
-        self.settings.max_dht_queries_per_ip_per_second = limit;
-        self
-    }
+//     /// Rate the number of DHT queries by ip addresses. 0 = disabled.
+//     pub fn max_dht_queries_per_ip_per_second(mut self, limit: u32) -> Self {
+//         self.settings.max_dht_queries_per_ip_per_second = limit;
+//         self
+//     }
 
-    /// Burst size of the rate limit. 0 = disabled.
-    pub fn max_dht_queries_per_ip_burst(mut self, burst: u32) -> Self {
-        self.settings.max_dht_queries_per_ip_burst = burst;
-        self
-    }
+//     /// Burst size of the rate limit. 0 = disabled.
+//     pub fn max_dht_queries_per_ip_burst(mut self, burst: u32) -> Self {
+//         self.settings.max_dht_queries_per_ip_burst = burst;
+//         self
+//     }
 
-    pub fn build_settings(self) -> ResolverSettings {
-        self.settings
-    }
-}
+//     pub fn build_settings(self) -> ResolverSettings {
+//         self.settings
+//     }
+// }
 
 /**
  * Pkarr resolver with cache.
@@ -171,9 +171,9 @@ impl PkarrResolver {
         Self::new(ResolverSettings::default()).await
     }
 
-    pub fn builder() -> PkarrResolverBuilder {
-        PkarrResolverBuilder::new()
-    }
+    // pub fn builder() -> PkarrResolverBuilder {
+    //     PkarrResolverBuilder::new()
+    // }
 
     pub async fn new(settings: ResolverSettings) -> Self {
         let addrs = Self::resolve_bootstrap_nodes(&settings.forward_dns_server);
@@ -324,7 +324,7 @@ impl PkarrResolver {
 
         match self.resolve_pubkey_respect_cache(&pubkey, from).await {
             Ok(item) => {
-                if item.is_not_found() {
+                if item.not_found() {
                     return Ok(create_domain_not_found_reply(request.id()));
                 };
 
@@ -335,7 +335,6 @@ impl PkarrResolver {
                 let reply = if removed_tld {
                     let mut packet = Packet::parse(&reply).unwrap();
                     self.add_tld_if_necessary(&mut packet);
-
                     packet.build_bytes_vec().unwrap()
                 } else {
                     reply

--- a/server/src/resolution/pkd/top_level_domain.rs
+++ b/server/src/resolution/pkd/top_level_domain.rs
@@ -41,7 +41,10 @@ impl TopLevelDomain {
             .to_string();
 
         if question_tld != self.0 {
-            panic!("Question tld {question_tld} does not match the given tld .{}", self.label());
+            panic!(
+                "Question tld {question_tld} does not match the given tld .{}",
+                self.label()
+            );
         }
 
         let second_label = labels.get(labels.len() - 2).expect("Question should have 2 labels");
@@ -259,10 +262,7 @@ mod tests {
             "7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd"
         );
         let answer2_domain = packet.answers.get(1).unwrap().name.to_string();
-        assert_eq!(
-            answer2_domain,
-            "example.com"
-        );
+        assert_eq!(answer2_domain, "example.com");
     }
 
     #[tokio::test]
@@ -287,9 +287,6 @@ mod tests {
             "test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd"
         );
         let answer2_domain = packet.answers.get(1).unwrap().name.to_string();
-        assert_eq!(
-            answer2_domain,
-            "example.com"
-        );
+        assert_eq!(answer2_domain, "example.com");
     }
 }

--- a/server/src/resolution/pkd/top_level_domain.rs
+++ b/server/src/resolution/pkd/top_level_domain.rs
@@ -1,0 +1,295 @@
+use simple_dns::{Name, Packet, Question, ResourceRecord};
+
+use super::pubkey_parser::parse_pkarr_uri;
+
+/// Top Level Domain like .pkd with the capability
+/// to remove and add the top level domain in queries/replies.
+#[derive(Clone, Debug)]
+pub struct TopLevelDomain(pub String);
+
+impl TopLevelDomain {
+    pub fn new(tld: String) -> Self {
+        Self(tld)
+    }
+
+    pub fn label(&self) -> &str {
+        &self.0
+    }
+
+    /// Checks if the query or reply contains a question that ends with a public key and the tld.
+    pub fn question_ends_with_pubkey_tld(&self, packet: &Packet<'_>) -> bool {
+        let question = packet.questions.first();
+        if question.is_none() {
+            return false;
+        }
+        let question = question.unwrap();
+        self.name_ends_with_pubkey_tld(&question.qname)
+    }
+
+    /// Removes the top level domain from the query if it exists.
+    /// Returns the new query and a flag if the tld has been removed.
+    pub fn remove(&self, packet: &mut Packet<'_>) {
+        let question = packet
+            .questions
+            .first()
+            .expect("No question in query in pkarr_resolver.");
+        let labels = question.qname.get_labels();
+
+        let mut question_tld = labels
+            .last()
+            .expect("Question labels with no domain in pkarr_resolver")
+            .to_string();
+
+        if question_tld != self.0 {
+            panic!("Question tld {question_tld} does not match the given tld .{}", self.label());
+        }
+
+        let second_label = labels.get(labels.len() - 2).expect("Question should have 2 labels");
+        let parse_res = parse_pkarr_uri(&second_label.to_string()).expect("Second label must be a pkarr public key");
+
+        let slice = &labels[0..labels.len() - 1];
+        let new_domain = slice
+            .iter()
+            .map(|label| label.to_string())
+            .collect::<Vec<String>>()
+            .join(".");
+
+        let name = Name::new(&new_domain).unwrap().into_owned();
+        let new_question = Question::new(
+            name,
+            question.qtype.clone(),
+            question.qclass.clone(),
+            question.unicast_response,
+        )
+        .into_owned();
+        packet.questions = vec![new_question];
+    }
+
+    /// Checks if the name ends with a public key domain and the tld.
+    pub fn name_ends_with_pubkey_tld(&self, name: &Name<'_>) -> bool {
+        let labels = name.get_labels();
+        if labels.len() < 2 {
+            // Needs at least 2 labels. First: tld, second: publickey
+            return false;
+        }
+
+        let mut question_tld = labels.last().unwrap().to_string();
+
+        if question_tld != self.0 {
+            return false;
+        };
+
+        let second_label = labels.get(labels.len() - 2).unwrap().to_string();
+        return parse_pkarr_uri(&second_label).is_ok();
+    }
+
+    /// Checks if the name ends with a public key domain
+    pub fn name_ends_with_pubkey(&self, name: &Name<'_>) -> bool {
+        let labels = name.get_labels();
+        if labels.len() < 1 {
+            // Needs at least 2 labels. First: tld, second: publickey
+            return false;
+        }
+
+        let mut question_tld = labels.last().unwrap().to_string();
+        return parse_pkarr_uri(&question_tld).is_ok();
+    }
+
+    /// Append the top level domain to the reply. Zones are stored without a tld on Mainline
+    /// so we need to add it again here.
+    pub fn add(&self, reply: &mut Packet<'_>) {
+        // Append questions
+        let mut new_questions = vec![];
+        for mut question in reply.questions.iter() {
+            if !self.name_ends_with_pubkey(&question.qname) {
+                // Other question. Don't change.
+                new_questions.push(question.clone());
+                continue;
+            };
+            let original_domain = question.qname.to_string();
+            let new_domain = format!("{original_domain}.{}", self.0);
+            let new_name = Name::new(&new_domain).unwrap();
+            let new_question =
+                Question::new(new_name, question.qtype, question.qclass, question.unicast_response).into_owned();
+            new_questions.push(new_question);
+        }
+        reply.questions = new_questions;
+        // Append answers
+        let mut new_answers = vec![];
+        for mut answer in reply.answers.iter() {
+            if !self.name_ends_with_pubkey(&answer.name) {
+                // Other answer. Don't change.
+                new_answers.push(answer.clone());
+                continue;
+            };
+            let original_domain = answer.name.to_string();
+            let new_domain = format!("{original_domain}.{}", self.0);
+            let new_name = Name::new(&new_domain).unwrap();
+            let new_answer = ResourceRecord::new(new_name, answer.class, answer.ttl, answer.rdata.clone()).into_owned();
+            new_answers.push(new_answer);
+        }
+        reply.answers = new_answers;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use simple_dns::rdata::A;
+    use std::net::Ipv4Addr;
+    use zbase32;
+
+    fn create_query_with_domain(domain: &str) -> Vec<u8> {
+        let tld = TopLevelDomain::new("pkd".to_string());
+
+        let name = Name::new(domain).unwrap();
+        let mut query = Packet::new_query(0);
+        let question = Question::new(
+            name.clone(),
+            pkarr::dns::QTYPE::TYPE(pkarr::dns::TYPE::A),
+            pkarr::dns::QCLASS::CLASS(pkarr::dns::CLASS::IN),
+            true,
+        );
+        query.questions.push(question);
+        query.build_bytes_vec().unwrap()
+    }
+
+    fn create_reply_with_domain(domain: &str) -> Vec<u8> {
+        let query = create_query_with_domain(domain);
+        let mut packet = Packet::parse(&query).unwrap().into_reply();
+
+        let rdata = simple_dns::rdata::RData::A(A { address: 0 });
+        let answer1 = ResourceRecord::new(Name::new(domain).unwrap(), simple_dns::CLASS::IN, 60, rdata.clone());
+        packet.answers.push(answer1);
+
+        let answer2 = ResourceRecord::new(Name::new("example.com").unwrap(), simple_dns::CLASS::IN, 60, rdata);
+        packet.answers.push(answer2);
+
+        packet.build_bytes_vec().unwrap()
+    }
+
+    #[tokio::test]
+    async fn is_pkarr_with_tld_valid_2_label() {
+        let tld = TopLevelDomain::new("pkd".to_string());
+        let domain = create_query_with_domain("7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd");
+        let packet = Packet::parse(&domain).unwrap();
+        assert_eq!(tld.question_ends_with_pubkey_tld(&packet), true);
+    }
+
+    #[tokio::test]
+    async fn is_pkarr_with_tld_valid_3_label() {
+        let tld = TopLevelDomain::new("pkd".to_string());
+        let domain = create_query_with_domain("test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd");
+        let packet = Packet::parse(&domain).unwrap();
+        assert_eq!(tld.question_ends_with_pubkey_tld(&packet), true);
+    }
+
+    #[tokio::test]
+    async fn is_pkarr_with_tld_fail_1_label() {
+        let tld = TopLevelDomain::new("pkd".to_string());
+        let domain = create_query_with_domain("pkd");
+        let packet = Packet::parse(&domain).unwrap();
+        assert_eq!(tld.question_ends_with_pubkey_tld(&packet), false);
+    }
+
+    #[tokio::test]
+    async fn is_pkarr_with_tld_fail_2_label_no_pubkey() {
+        let tld = TopLevelDomain::new("nopubkey.pkd".to_string());
+        let domain = create_query_with_domain("pkd");
+        let packet = Packet::parse(&domain).unwrap();
+        assert_eq!(tld.question_ends_with_pubkey_tld(&packet), false);
+    }
+
+    #[tokio::test]
+    async fn is_pkarr_with_tld_fail_2_label_wrong_tld() {
+        let tld = TopLevelDomain::new("7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.wrongpkd".to_string());
+        let domain = create_query_with_domain("pkd");
+        let packet = Packet::parse(&domain).unwrap();
+        assert_eq!(tld.question_ends_with_pubkey_tld(&packet), false);
+    }
+
+    #[tokio::test]
+    async fn remove_tld_success_2_labels() {
+        let tld = TopLevelDomain::new("pkd".to_string());
+        let domain = create_query_with_domain("7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd");
+        let mut packet = Packet::parse(&domain).unwrap();
+        tld.remove(&mut packet);
+        // Rebuild packet from scratch
+        let removed_query = packet.build_bytes_vec().unwrap();
+        let packet = Packet::parse(&removed_query).unwrap();
+        let question_domain = packet.questions.first().unwrap().qname.to_string();
+        assert_eq!(question_domain, "7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy")
+    }
+
+    #[tokio::test]
+    async fn remove_tld_success_3_labels() {
+        let tld = TopLevelDomain::new("pkd".to_string());
+        let domain = create_query_with_domain("test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd");
+        let mut packet = Packet::parse(&domain).unwrap();
+        tld.remove(&mut packet);
+        // Rebuild packet from scratch
+        let removed_query = packet.build_bytes_vec().unwrap();
+        let packet = Packet::parse(&removed_query).unwrap();
+        let question_domain = packet.questions.first().unwrap().qname.to_string();
+        assert_eq!(
+            question_domain,
+            "test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy"
+        )
+    }
+
+    #[tokio::test]
+    async fn add_success_1_label() {
+        let tld = TopLevelDomain::new("pkd".to_string());
+        let domain = create_reply_with_domain("7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy");
+        let mut packet = Packet::parse(&domain).unwrap();
+        tld.add(&mut packet);
+        // Rebuild packet from scratch
+        let removed_query = packet.build_bytes_vec().unwrap();
+        let packet = Packet::parse(&removed_query).unwrap();
+
+        let question_domain = packet.questions.first().unwrap().qname.to_string();
+        assert_eq!(
+            question_domain,
+            "7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd"
+        );
+
+        let answer1_domain = packet.answers.first().unwrap().name.to_string();
+        assert_eq!(
+            answer1_domain,
+            "7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd"
+        );
+        let answer2_domain = packet.answers.get(1).unwrap().name.to_string();
+        assert_eq!(
+            answer2_domain,
+            "example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_success_2_label() {
+        let tld = TopLevelDomain("pkd".to_string());
+        let domain = create_reply_with_domain("test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy");
+        let mut packet = Packet::parse(&domain).unwrap();
+        tld.add(&mut packet);
+        // Rebuild packet from scratch
+        let removed_query = packet.build_bytes_vec().unwrap();
+        let packet = Packet::parse(&removed_query).unwrap();
+
+        let question_domain = packet.questions.first().unwrap().qname.to_string();
+        assert_eq!(
+            question_domain,
+            "test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd"
+        );
+
+        let answer1_domain = packet.answers.first().unwrap().name.to_string();
+        assert_eq!(
+            answer1_domain,
+            "test.7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd"
+        );
+        let answer2_domain = packet.answers.get(1).unwrap().name.to_string();
+        assert_eq!(
+            answer2_domain,
+            "example.com"
+        );
+    }
+}


### PR DESCRIPTION
Adds optional support for a top level domain (TLD) on Public Key Domains. Raw public keys keep being supported.

By default, `.pkd` is the default tld. The public key `7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy` can be resolved directly or with the tld like `7fmjpcuuzf54hw18bsgi3zihzyh4awseeuq5tmojefaezjbd64cy.pkd`.

The tld is configurable in the settings and can be changed.

Resolves #37 