### PR TITLE
fix(docker): Use amd64 instead of arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.20
 
-COPY ./target/aarch64-unknown-linux-musl/release/pkdns /usr/local/bin
-COPY ./target/aarch64-unknown-linux-musl/release/pkdns-cli /usr/local/bin
+COPY ./target/x86_64-unknown-linux-musl/release/pkdns /usr/local/bin
+COPY ./target/x86_64-unknown-linux-musl/release/pkdns-cli /usr/local/bin
 
 EXPOSE 53
 


### PR DESCRIPTION
Fixes the docker build. arm64 would only work on arm cpu. Switched to amd64 as it is the most widely used plattform.

Resolves #84 