### PR TITLE
CLI: Show usage when no args

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -8,6 +8,7 @@ pub async fn run_cli() {
 
     let cmd = clap::Command::new("pkarr-cli")
         .version(VERSION)
+        .arg_required_else_help(true)
         .subcommand(
             clap::Command::new("publish")
                 .about("Publish pkarr dns records.")


### PR DESCRIPTION
Configures clap to show the CLI usage if no arguments are provided.

I'm not particularly familiar with Clap or Rust, but this confused me when I was using the CLI, so figured I'd have a crack at fixing it!

It looks as though the subcommands might benefit from the same config; are there any you're expecting to operate without args? (`publish` looks like maybe?)