### PR TITLE
feat(cli): change the seed to hex format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2031,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "domain",
+ "hex",
  "pkarr",
  "rand",
  "reqwest",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ zbase32 = "0.1.2"
 ctrlc = "3.4.4"
 reqwest = { version="0.12.12", default-features = false, features = ["json", "rustls-tls", "http2"]}
 rand = {version = "0.8"}
+hex = "0.4.3"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -6,7 +6,7 @@ use crate::commands::{cli_publickey, generate::cli_generate_seed, publish::cli_p
 pub async fn run_cli() {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    let cmd = clap::Command::new("pkarr-cli")
+    let cmd = clap::Command::new("pkdns-cli")
         .version(VERSION)
         .arg_required_else_help(true)
         .subcommand(
@@ -14,7 +14,7 @@ pub async fn run_cli() {
                 .about("Publish pkarr dns records.")
                 .arg(
                     clap::Arg::new("seed")
-                        .help("File path to the pkarr seed file.")
+                        .help("File path to the seed file.")
                         .default_value("./seed.txt"),
                 )
                 .arg(
@@ -25,11 +25,11 @@ pub async fn run_cli() {
         )
         .subcommand(
             clap::Command::new("resolve")
-                .about("Resolve pkarr dns records.")
+                .about("Resolve a public key domain on the DHT.")
                 .arg_required_else_help(true)
-                .arg(clap::Arg::new("pubkey").required(false).help("Pkarr public key uri.")),
+                .arg(clap::Arg::new("pubkey").required(false).help("Public Key Domain")),
         )
-        .subcommand(clap::Command::new("generate").about("Generate a new zbase32 pkarr seed"))
+        .subcommand(clap::Command::new("generate").about("Generate a new seed"))
         .subcommand(
             clap::Command::new("publickey")
                 .about("Derive the public key from the seed.")

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -3,6 +3,6 @@ use pkarr::Keypair;
 
 pub async fn cli_generate_seed(_matches: &ArgMatches) {
     let keypair = Keypair::random();
-    let encoded = hex::encode(&keypair.secret_key());
+    let encoded = hex::encode(keypair.secret_key());
     println!("{encoded}");
 }

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -3,6 +3,6 @@ use pkarr::Keypair;
 
 pub async fn cli_generate_seed(_matches: &ArgMatches) {
     let keypair = Keypair::random();
-    let encoded = zbase32::encode_full_bytes(&keypair.secret_key());
+    let encoded = hex::encode(&keypair.secret_key());
     println!("{encoded}");
 }


### PR DESCRIPTION
Previously, the seed was saved in zbase32. This is not compliant with https://github.com/pubky/pkarr/pull/166.

This PR changes the seed to HEX. zbase32 seeds are still supported for backwards compatibility.