### PR TITLE
fix(hs): Panic when forward server answers late

### DIFF
--- a/server/src/resolution/dns_socket.rs
+++ b/server/src/resolution/dns_socket.rs
@@ -158,7 +158,7 @@ impl DnsSocket {
         let packet_id = packet.id();
         if let Some(query) = self.pending.remove_by_forward_id(&packet_id, &from) {
             tracing::trace!("Received response from forward server. Send back to client.");
-            query.tx.send(packet.into()).unwrap();
+            let _ = query.tx.send(packet.into()); // TODO: Handle error properly. Sometimes the channel is broken.
             return Ok(());
         };
 


### PR DESCRIPTION
Fixes

```
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]: 2025-08-15T01:56:11.689194Z ERROR pkdns: Thread paniced. Stop main thread too.
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]: thread 'tokio-runtime-worker' panicked at server/src/resolution/dns_socket.rs:161:42:
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]: called `Result::unwrap()` on an `Err` value: [20, 139, 129, 128, 0, 1, 0, 0, 0, 1, 0, 1, 5, 114, 101, 108, 97, 121, 4, 104, 111, 100, 108, 2, 97, 114, 0, 0, 65, 0, 1, 192, 18, 0, 6, 0, 1, 0, 0, 2, 88, 0, 62, 3, 110, 115, 49, 10, 118, 101, 114, 99, 101, 108, 45, 100, 110, 115, 3, 99, 111, 109, 0, 10, 104, 111, 115, 116, 109, 97, 115, 116, 101, 114, 5, 110, 115, 111, 110, 101, 3, 110, 101, 116, 0, 99, 241, 64, 192, 0, 0, 168, 192, 0, 0, 28, 32, 0, 18, 117, 0, 0, 0, 2, 88, 0, 0, 41, 2, 0, 0, 0, 0, 0, 0, 0, 0]
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]: stack backtrace:
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    0:     0x5974d868d49a - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h5b6bd5631a6d1f6b
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    1:     0x5974d86b4433 - core::fmt::write::h7550c97b06c86515
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    2:     0x5974d8689b63 - std::io::Write::write_fmt::h7b09c64fe0be9c84
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    3:     0x5974d868d2e2 - std::sys::backtrace::BacktraceLock::print::h2395ccd2c84ba3aa
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    4:     0x5974d868e75a - std::panicking::default_hook::{{closure}}::he19d4c7230e07961
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    5:     0x5974d868e5a0 - std::panicking::default_hook::hf614597d3c67bbdb
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    6:     0x5974d8184e6f - pkdns::main::{{closure}}::{{closure}}::h0ff0255a29c5efa7
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    7:     0x5974d868edf8 - std::panicking::rust_panic_with_hook::h8942133a8b252070
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    8:     0x5974d868ebba - std::panicking::begin_panic_handler::{{closure}}::hb5f5963570096b29
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:    9:     0x5974d868d979 - std::sys::backtrace::__rust_end_short_backtrace::h6208cedc1922feda
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   10:     0x5974d868e84c - rust_begin_unwind
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   11:     0x5974d80949f0 - core::panicking::panic_fmt::h0c3082644d1bf418
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   12:     0x5974d8094e36 - core::result::unwrap_failed::hd20b4aa073bda1e2
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   13:     0x5974d81eec77 - <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll::h9e2ba547e65d1b74
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   14:     0x5974d80b0119 - pkdns::resolution::dns_socket::DnsSocket::start_receive_loop::{{closure}}::hf8ff3cfa300dfa1b
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   15:     0x5974d80aa5b7 - tokio::runtime::task::core::Core<T,S>::poll::h8e3b9c38ab8a21ed
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   16:     0x5974d81ae2fb - tokio::runtime::task::harness::Harness<T,S>::poll::hcab4e14dac30e899
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   17:     0x5974d85c2369 - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::hbba5d4256dbec95d
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   18:     0x5974d85c1451 - tokio::runtime::scheduler::multi_thread::worker::Context::run::hec092dd1f8624f10
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   19:     0x5974d85d7506 - tokio::runtime::context::runtime::enter_runtime::h110ff98ef0bfda0f
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   20:     0x5974d85c12ba - tokio::runtime::scheduler::multi_thread::worker::run::h95fd0532accf7921
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   21:     0x5974d85c7577 - <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::hdd9f8ca9557c400b
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   22:     0x5974d85df433 - tokio::runtime::task::core::Core<T,S>::poll::ha6f60126ead636a2
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   23:     0x5974d85bd2d4 - tokio::runtime::task::harness::Harness<T,S>::poll::h9e20fc23e7dcab51
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   24:     0x5974d85d5702 - tokio::runtime::blocking::pool::Inner::run::hfd3f6aa31c846c37
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   25:     0x5974d85cdc3e - std::sys::backtrace::__rust_begin_short_backtrace::h9ae78e2ef73ceda6
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   26:     0x5974d85ce449 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h7726febb719d9f84
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   27:     0x5974d869144b - std::sys::pal::unix::thread::Thread::new::thread_start::hcc78f3943333fa94
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   28:     0x762ffe09caa4 - <unknown>
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   29:     0x762ffe129c3c - <unknown>
Aug 15 01:56:11 pkdns.europe-west6-b.c.pubky-prod.internal pkdns[3398084]:   30:                0x0 - <unknown>
```